### PR TITLE
Remove siren-parser CDN references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_script:
 - npm run test:lint
 script:
 - set -e
-- xvfb-run wct test --skip-plugin sauce
-- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then xvfb-run wct test --skip-plugin local; fi'
+- xvfb-run polymer test --skip-plugin sauce
+- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then xvfb-run polymer test --skip-plugin local; fi'
 - 'if [ "$TRAVIS_BRANCH" == "master" ]; then frauci-update-version; fi'
 env:
   global:

--- a/test/components/d2l-rubric-criteria-group.html
+++ b/test/components/d2l-rubric-criteria-group.html
@@ -5,7 +5,6 @@
 		<title>d2l-rubric-criteria-group test</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="https://s.brightspace.com/lib/siren-parser/6.5.0/siren-parser.js"></script>
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
 

--- a/test/components/d2l-rubric.html
+++ b/test/components/d2l-rubric.html
@@ -5,7 +5,6 @@
 		<title>d2l-rubric test</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="https://s.brightspace.com/lib/siren-parser/6.5.0/siren-parser.js"></script>
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
 
@@ -24,9 +23,9 @@
 				<d2l-rubric></d2l-rubric>
 			</template>
 		</test-fixture>
-		  
-		  <script>
+
+		<script>
 			a11ySuite('basic');
-		  </script>
+		</script>
 	</body>
 </html>

--- a/test/index.html
+++ b/test/index.html
@@ -5,7 +5,6 @@
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 		<script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../bower_components/web-component-tester/browser.js"></script>
-		<script src="https://s.brightspace.com/lib/siren-parser/6.5.0/siren-parser.js"></script>
 	</head>
 	<body>
 		<script>


### PR DESCRIPTION
These are not currently being used, and if their functionality is required, it is advisable to instead use `siren-parser-import` to avoid any potential versioning problems.

This is somewhat out of nowhere so I apologize for that - there was a DE that was just found that was causing by using direct references to the CDN-ified script rather than using `siren-parser-import`, so I'm going around and removing CDN-ified script references. Not really required here since it's only in the tests, but they're not being used anyway so figured I'd remove them :) 