### PR TITLE
upgrading bower dependencies to include latest and ^ ranges

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,22 +4,22 @@
   "main": "d2l-rubric.html",
   "license": "Apache-2.0",
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.11.2",
-    "d2l-fetch-siren-entity-behavior": "Brightspace/d2l-fetch-siren-entity-behavior#~4.0.1",
+    "d2l-fetch-siren-entity-behavior": "Brightspace/d2l-fetch-siren-entity-behavior#^4.0.2",
     "d2l-table": "BrightspaceUI/table#^1.2.0",
     "d2l-fetch": "Brightspace/d2l-fetch#^1.8.0",
-    "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#5.0.0",
+    "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^5.1.0",
     "d2l-colors": "^3.1.2",
-    "d2l-localize-behavior": "~1.1.0",
-    "d2l-typography": "^6.1.2"
+    "d2l-localize-behavior": "^1.1.0",
+    "d2l-typography": "^6.1.2",
+    "polymer": "Polymer/polymer#^1.11.2"
   },
   "resolutions": {
     "webcomponentsjs": "^0.7.24"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^3.0.0",
+    "iron-component-page": "PolymerElements/iron-component-page#^3.0.1",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
-    "web-component-tester": "Polymer/web-component-tester#^6.0.0",
+    "web-component-tester": "Polymer/web-component-tester#^6.5.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.24"
   }
 }


### PR DESCRIPTION
Since you're integrating with BSI, it's important to include `^` in your version ranges, which will allow it to pick up patch and minor version changes. If you exclude that, everything needs to use the exact same version, which is really hard to keep in sync. The `~` on the other hand only allows for patch version increases, not minor versions.