### PR TITLE
Default entity to null and guard against it

### DIFF
--- a/d2l-rubric-criteria-group-mobile.html
+++ b/d2l-rubric-criteria-group-mobile.html
@@ -41,6 +41,9 @@
 			],
 
 			_onEntityChanged: function(entity) {
+				if (!entity) {
+					return;
+				}
 				this._name = entity.properties.name;
 				this._levelsHref = this._getLevelsLink(entity);
 				this._criteriaHref = this._getCriteriaLink(entity);

--- a/d2l-rubric-criteria-group.html
+++ b/d2l-rubric-criteria-group.html
@@ -130,6 +130,9 @@
 			],
 
 			_onEntityChanged: function(entity) {
+				if (!entity) {
+					return;
+				}
 				this._levelsHref = this._getLevelsLink(entity);
 				this._criteriaCollectionHref = this._getCriteriaLink(entity);
 			},

--- a/d2l-rubric-criteria-groups.html
+++ b/d2l-rubric-criteria-groups.html
@@ -52,6 +52,9 @@
 			],
 
 			_onEntityChanged: function(entity) {
+				if (!entity) {
+					return;
+				}
 				this._groups = entity.getSubEntitiesByClass(this.HypermediaClasses.rubrics.criteriaGroup);
 			},
 

--- a/d2l-rubric-criteria-mobile.html
+++ b/d2l-rubric-criteria-mobile.html
@@ -48,6 +48,9 @@
 			],
 
 			_onEntityChanged: function(entity) {
+				if (!entity) {
+					return;
+				}
 				this._criteria = entity.getSubEntitiesByClass(this.HypermediaClasses.rubrics.criterion);
 			},
 

--- a/d2l-rubric-criterion-mobile.html
+++ b/d2l-rubric-criterion-mobile.html
@@ -164,6 +164,9 @@
 			],
 
 			_onEntityChanged: function(entity) {
+				if (!entity) {
+					return;
+				}
 				this._name = entity.properties.name;
 				this._outOf = entity.properties.outOf;
 				this._criterionCells = entity.getSubEntitiesByClass(this.HypermediaClasses.rubrics.criterionCell);

--- a/d2l-rubric-levels-mobile.html
+++ b/d2l-rubric-levels-mobile.html
@@ -144,6 +144,9 @@
 			],
 
 			_onEntityChanged: function(entity) {
+				if (!entity) {
+					return;
+				}
 				this.total = entity.properties.total;
 				this._levelEntities = entity.getSubEntitiesByClass(this.HypermediaClasses.rubrics.level);
 			},

--- a/d2l-rubric-title.html
+++ b/d2l-rubric-title.html
@@ -28,6 +28,9 @@
 			],
 
 			_onEntityChanged: function(entity) {
+				if (!entity) {
+					return;
+				}
 				this._title = entity.properties.name;
 			}
 		});

--- a/siren-entity-behavior.html
+++ b/siren-entity-behavior.html
@@ -26,12 +26,11 @@
 			/**
 			 * The fetched siren entity
 			 */
-			entity: Object
+			entity: {
+				type: Object,
+				value: null
+			}
 		},
-
-		behaviors: [
-			D2L.PolymerBehaviors.FetchSirenEntityBehavior
-		],
 
 		observers: [
 			'_fetchEntity(href, token)'
@@ -41,7 +40,7 @@
 			if (!href) {
 				return;
 			}
-			this._fetchEntityWithToken(href, function() { return Promise.resolve(token); })
+			D2L.PolymerBehaviors.FetchSirenEntityBehavior._fetchEntityWithToken(href, function() { return Promise.resolve(token); })
 				.then(function(entity) {
 					this.entity = entity;
 				}.bind(this));


### PR DESCRIPTION
This causes entity to be considered when rendering, so for example, the hasOutOf will be false until we get a valid entity.

Switch the siren-entity-behavior to use the fetch entity directly rather than adding it as a behavior.