### PR TITLE
Sdharme/mobile accessibility and ui cleanup

### DIFF
--- a/d2l-rubric-criteria-group.html
+++ b/d2l-rubric-criteria-group.html
@@ -36,6 +36,8 @@
 			}
 			.group-name {
 				@apply --d2l-body-standard-text;
+				font-size: 16px;
+				font-weight: bold;
 				text-align: left;
 				background-color: var(--d2l-table-header-background-color);
 			}
@@ -101,7 +103,7 @@
 						</template>
 						<template is="dom-if" if="[[_hasOutOf(entity)]]">
 							<d2l-td class="out-of">
-								<div>/[[item.properties.outOf]]</div>
+								<div> [[localize('outOf', 'outOf', item.properties.outOf)]] </div>
 							</d2l-td>
 						</template>
 					</d2l-tr>

--- a/d2l-rubric-criteria-group.html
+++ b/d2l-rubric-criteria-group.html
@@ -35,8 +35,7 @@
 				font-weight: 700;
 			}
 			.group-name {
-				@apply --d2l-body-standard-text;
-				font-size: 16px;
+				@apply --d2l-body-compact-text;
 				font-weight: bold;
 				text-align: left;
 				background-color: var(--d2l-table-header-background-color);

--- a/d2l-rubric-criteria-groups.html
+++ b/d2l-rubric-criteria-groups.html
@@ -14,7 +14,7 @@
 				display: block;
 			}
 			d2l-rubric-criteria-group {
-				margin-bottom: 24px;
+				padding-bottom: 24px;
 			}
 		</style>
 

--- a/d2l-rubric-levels-mobile.html
+++ b/d2l-rubric-levels-mobile.html
@@ -28,14 +28,21 @@
 				overflow: hidden;
 				text-align: center;
 				color: var(--d2l-color-galena);
+				outline: none;				
 			}
 			.level:hover {
 				cursor: pointer;
+				background-color: var(--d2l-color-gypsum);
 			}
 			.level.selected {
 				background-color: var(--d2l-color-regolith);
 				border: solid 1px var(--d2l-color-galena);
 				box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+			}
+			.level:focus, .level.selected:focus {
+				background-color: var(--d2l-color-gypsum);
+				box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.4);
+				z-index: 0;
 			}
 			.level.selected + .level {
 				border-left: none;
@@ -83,9 +90,9 @@
 			}
 		</style>
 		<div class="levels-container">
-			<div class="levels">
+			<div class="levels" role="tablist">
 				<template is="dom-repeat" items="[[_levelEntities]]">
-					<div class$="[[_getLevelClassName(index, selected)]]" on-tap="_selectLevel" data-index="[[index]]">
+					<div class$="[[_getLevelClassName(index, selected)]]" on-tap="_selectLevel" data-index="[[index]]" role="tab" on-keydown="_onKeyDown" tabindex="0">
 						<div class$="[[_getLevelTextClassName(index, selected)]]">
 							[[item.properties.name]]
 						</div>
@@ -156,6 +163,26 @@
 				'_onEntityChanged(entity)',
 				'_getSelectedProperties(_levelEntities, selected)'
 			],
+
+			_onKeyDown: function (event) {
+				switch (event.keyCode) {
+					case 13:
+						this.selected = event.currentTarget.dataIndex
+						break;
+					case 37:
+						if (event.currentTarget.dataIndex !== 0) {
+							event.currentTarget.previousSibling.focus();
+							event.preventDefault();							
+						}
+						break;
+					case 39:
+						if (event.currentTarget.dataIndex !== this.total - 1) {
+							event.currentTarget.nextSibling.focus()
+							event.preventDefault();				
+						}
+						break;
+				}
+			},
 
 			_onEntityChanged: function(entity) {
 				if (!entity) {

--- a/d2l-rubric-levels-mobile.html
+++ b/d2l-rubric-levels-mobile.html
@@ -92,7 +92,7 @@
 		<div class="levels-container">
 			<div class="levels" role="tablist">
 				<template is="dom-repeat" items="[[_levelEntities]]">
-					<div class$="[[_getLevelClassName(index, selected)]]" on-tap="_selectLevel" data-index="[[index]]" role="tab" on-keydown="_onKeyDown" tabindex="0">
+					<div class$="[[_getLevelClassName(index, selected)]]" on-tap="_selectLevel" data-index="[[index]]" role="tab" on-keydown="_onKeyDown" tabindex="0" aria-selected$="{{_isSelected(index, selected)}}">
 						<div class$="[[_getLevelTextClassName(index, selected)]]">
 							[[item.properties.name]]
 						</div>
@@ -164,21 +164,31 @@
 				'_getSelectedProperties(_levelEntities, selected)'
 			],
 
-			_onKeyDown: function (event) {
+			_keyCodes: {
+				ENTER: 13,
+				LEFT: 37,
+				RIGHT: 39
+			},
+
+			_isSelected: function(index, selected) {
+				return index === selected;
+			},
+
+			_onKeyDown: function(event) {
 				switch (event.keyCode) {
-					case 13:
-						this.selected = event.currentTarget.dataIndex
+					case this._keyCodes.ENTER:
+						this.selected = event.currentTarget.dataIndex;
 						break;
-					case 37:
+					case this._keyCodes.LEFT:
 						if (event.currentTarget.dataIndex !== 0) {
 							event.currentTarget.previousSibling.focus();
-							event.preventDefault();							
+							event.preventDefault();
 						}
 						break;
-					case 39:
+					case this._keyCodes.RIGHT:
 						if (event.currentTarget.dataIndex !== this.total - 1) {
-							event.currentTarget.nextSibling.focus()
-							event.preventDefault();				
+							event.currentTarget.nextSibling.focus();
+							event.preventDefault();
 						}
 						break;
 				}

--- a/d2l-rubric-levels-mobile.html
+++ b/d2l-rubric-levels-mobile.html
@@ -92,7 +92,15 @@
 		<div class="levels-container">
 			<div class="levels" role="tablist">
 				<template is="dom-repeat" items="[[_levelEntities]]">
-					<div class$="[[_getLevelClassName(index, selected)]]" on-tap="_selectLevel" data-index="[[index]]" role="tab" on-keydown="_onKeyDown" tabindex="0" aria-selected$="{{_isSelected(index, selected)}}">
+					<div
+						class$="[[_getLevelClassName(index, selected)]]"
+						on-tap="_selectLevel"
+						data-index="[[index]]"
+						role="tab"
+						on-keydown="_onKeyDown"
+						tabindex="0"
+						aria-selected$="[[_isSelected(index, selected)]]"
+					>
 						<div class$="[[_getLevelTextClassName(index, selected)]]">
 							[[item.properties.name]]
 						</div>
@@ -170,10 +178,6 @@
 				RIGHT: 39
 			},
 
-			_isSelected: function(index, selected) {
-				return index === selected;
-			},
-
 			_onKeyDown: function(event) {
 				switch (event.keyCode) {
 					case this._keyCodes.ENTER:
@@ -192,6 +196,10 @@
 						}
 						break;
 				}
+			},
+
+			_isSelected: function(index, selected) {
+				return index === selected;
 			},
 
 			_onEntityChanged: function(entity) {

--- a/d2l-rubric-levels-mobile.html
+++ b/d2l-rubric-levels-mobile.html
@@ -65,8 +65,8 @@
 			.out-of {
 				border-radius: 6px;
 				border: solid 1px var(--d2l-color-mica);
-				width: 60px;
-				min-width: 60px;
+				width: 40px;
+				min-width: 40px;
 				margin-left: 15px;
 				margin-right: 5px;
 			}
@@ -76,6 +76,7 @@
 			}
 			.out-of:hover {
 				cursor: default;
+				background-color: transparent;
 			}
 			[hidden] {
 				display: none !important;

--- a/lang/en.html
+++ b/lang/en.html
@@ -14,7 +14,7 @@
 		en: {
 			'levelNameAndPoints': '{levelName} - {number} {number, plural, one {point} other {points}}',
 			'levelNameAndPercentage': '{levelName} - {number} %',
-			'outOf': '\u2014 / {outOf}',
+			'outOf': '/\u00A0{outOf}',
 			'points': '{number} {number, plural, one {point} other {points}}',
 			'percentage': '{number} %',
 			'rubricSummaryA11y': 'This table lists criteria and criteria group name in the first column. The first row lists level names and includes scores if the rubric uses a numeric scoring method.',


### PR DESCRIPTION
- Adding keyboard accessibility to mobile view for levels
- Reduce criteria group font size and bold
- Fix space between criteria groups
- Modify langterm to show `/ 4` instead of `- / 4` and reduce `out-of` div width