### PR TITLE
Fix breaking minification

### DIFF
--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -181,7 +181,7 @@
 			<template is="dom-repeat" items="[[_criteriaEntities]]">
 				<div class="row criterion">
 					<div class="cell col-first criterion-name">
-						<d2l-textarea no-border hover-styles value=[[item.properties.name]] placeholder=[[localize( 'criterionPlaceholder')]]></d2l-textarea>
+						<d2l-textarea no-border hover-styles value=[[item.properties.name]] placeholder="[[localize('criterionPlaceholder')]]"></d2l-textarea>
 					</div>
 					<div class="criterion-detail">
 						<div class="inner-row criterion-text">


### PR DESCRIPTION
My LMS PR that references the newest `brightspace-integration` CDN url keeps failing, something about missing version.
I checked the travis build for the tag, which is supposed to deploy the build to the CDN, and I saw that it failed to minify a d2l-rubric file: https://travis-ci.org/Brightspace/brightspace-integration/jobs/376099995#L5503

I don't know if this is the reason for the LMS tests failing, but possibly...?

I could reproduce the 'failed to minify error' when I run `polymer build` in `brightspace-integration`.
After the fix in this PR, `polymer build` no longer produces the error.