### PR TITLE
fix border margin on ipad

### DIFF
--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -25,6 +25,7 @@
 					height: 100%;
 					overflow: hidden;
 					hyphens: auto;
+					-webkit-appearance: none;
 				};
 			}
 


### PR DESCRIPTION
iPad and iPhone add a margin-left of -3px to textarea for some reason. I think this fixes the issue, but I have no way to test this locally.