### PR TITLE
Add basic load/save error handling for the rubric editor

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,7 @@
     "iron-resizable-behavior": "^2.1.0",
     "polymer": "1 - 2",
     "s-html": "Brightspace/s-html#^1.0.0",
-    "d2l-textarea": "BrightspaceUI/textarea#^0.4.0",
+    "d2l-textarea": "BrightspaceUI/textarea#^0.5.0",
     "d2l-text-input": "BrightspaceUI/text-input#^0.3.0"
   },
   "devDependencies": {

--- a/demo/d2l-rubric-editor.html
+++ b/demo/d2l-rubric-editor.html
@@ -41,6 +41,7 @@
 </head>
 <body class="d2l-typography">
 <div class="vertical-section-container">
+	<!--
 	<h1>d2l-rubric-editor demo</h1>
 	<h3>Rubric Editor, text only</h3>
 	<demo-snippet>
@@ -65,11 +66,23 @@
 	<demo-snippet>
 		<d2l-rubric-editor href="data/rubrics/organizations/multiple-groups/203.json" token="foozleberries"></d2l-rubric-editor>
 	</demo-snippet>
+-->
+	<h3>Rubric loading error</h3>
+	<demo-snippet>
+		<d2l-rubric-editor href="404.json" token="foozleberries"></d2l-rubric-editor>
+	</demo-snippet>
 
+	<h3>Rubric saving error</h3>
+	<demo-snippet>
+		<d2l-rubric-editor href="static-data/rubrics/organizations/text-only/199.json" token="foozleberries"></d2l-rubric-editor>
+	</demo-snippet>
+
+<!--
 	<h3>Rubric loading</h3>
 	<demo-snippet>
 		<d2l-rubric-loading></d2l-rubric-loading>
 	</demo-snippet>
+-->
 
 </div>
 </body>

--- a/demo/d2l-rubric-editor.html
+++ b/demo/d2l-rubric-editor.html
@@ -41,7 +41,7 @@
 </head>
 <body class="d2l-typography">
 <div class="vertical-section-container">
-	<!--
+
 	<h1>d2l-rubric-editor demo</h1>
 	<h3>Rubric Editor, text only</h3>
 	<demo-snippet>
@@ -66,23 +66,21 @@
 	<demo-snippet>
 		<d2l-rubric-editor href="data/rubrics/organizations/multiple-groups/203.json" token="foozleberries"></d2l-rubric-editor>
 	</demo-snippet>
--->
+
 	<h3>Rubric loading error</h3>
 	<demo-snippet>
 		<d2l-rubric-editor href="404.json" token="foozleberries"></d2l-rubric-editor>
 	</demo-snippet>
 
-	<h3>Rubric saving error</h3>
+	<h3>Rubric saving error (modify Criterion 1 name to see error)</h3>
 	<demo-snippet>
 		<d2l-rubric-editor href="static-data/rubrics/organizations/text-only/199.json" token="foozleberries"></d2l-rubric-editor>
 	</demo-snippet>
 
-<!--
 	<h3>Rubric loading</h3>
 	<demo-snippet>
 		<d2l-rubric-loading></d2l-rubric-loading>
 	</demo-snippet>
--->
 
 </div>
 </body>

--- a/demo/static-data/rubrics/organizations/text-only/199.json
+++ b/demo/static-data/rubrics/organizations/text-only/199.json
@@ -1,0 +1,56 @@
+{
+    "class": [
+        "rubric",
+        "published"
+    ],
+    "properties": {
+        "name": "Text Only Rubric"
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only.json"
+        },
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criteria-groups"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups.json"
+        },
+        {
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "href": "static-data/rubrics/organizations/text-only.json"
+        },
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/overall-levels"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/overallLevels.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups.json
@@ -1,0 +1,60 @@
+{
+    "class": [
+        "collection",
+        "criteria-groups"
+    ],
+    "entities": [
+        {
+            "class": [
+                "criteria-group"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criteria",
+                "item"
+            ],
+            "properties": {
+                "name": "Criteria"
+            },
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/criteria"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria.json"
+                },
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/levels"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176.json
@@ -1,0 +1,34 @@
+{
+    "class": [
+        "criteria-group"
+    ],
+    "properties": {
+        "name": "Criteria"
+    },
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criteria"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria.json"
+        },
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/levels"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria.json
@@ -1,0 +1,797 @@
+{
+    "class": [
+        "collection",
+        "criteria"
+    ],
+    "entities": [
+        {
+            "class": [
+                "criterion"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criterion"
+            ],
+            "properties": {
+                "name": "Criterion 1"
+            },
+            "actions": [{
+              "name": "update",
+              "method": "PUT",
+              "href":  "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json",
+              "fields": [{
+                "type": "text",
+                "name": "name",
+                "value": "Criterion 1"
+              }]
+            }],
+            "entities": [
+                {
+                    "class": [
+                        "criterion-cell"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "Proper use of grammar",
+                                "html": "Proper use of grammar"
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/3.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criterion"
+            ],
+            "properties": {
+                "name": "Criterion 2"
+            },
+            "entities": [
+                {
+                    "class": [
+                        "criterion-cell"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/0.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/1.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/2.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/3.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criterion"
+            ],
+            "properties": {
+                "name": "Criterion 3"
+            },
+            "entities": [
+                {
+                    "class": [
+                        "criterion-cell"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/0.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/1.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/2.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/3.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623-name-mod.js
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623-name-mod.js
@@ -1,0 +1,81 @@
+/*eslint quotes: 0 */
+window.testFixtures = window.testFixtures || {};
+
+Object.assign(window.testFixtures, {
+	get criterion_name_mod() {
+		return {
+			"class": [
+				"criterion"
+			],
+			"properties": {
+				"name": "Batman and Robin"
+			},
+			"actions": [{
+				"name": "update",
+				"method": "PUT",
+				"href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json",
+				"fields": [{
+					"type": "text",
+					"name": "name",
+					"value": "Batman and Robin"
+				}]
+			}],
+			"entities": [
+				{
+					"class": [
+						"criterion-cell"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json"
+				},
+				{
+					"class": [
+						"criterion-cell"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json"
+				},
+				{
+					"class": [
+						"criterion-cell"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json"
+				},
+				{
+					"class": [
+						"criterion-cell"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/3.json"
+				}
+			],
+			"links": [
+				{
+					"rel": [
+						"self"
+					],
+					"href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+				},
+				{
+					"rel": [
+						"up"
+					],
+					"href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria.json"
+				}
+			]
+		};
+	}
+});

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json
@@ -1,0 +1,262 @@
+{
+    "class": [
+        "criterion"
+    ],
+    "properties": {
+        "name": "Criterion 1"
+    },
+    "actions": [{
+      "name": "update",
+      "method": "PUT",
+      "href":  "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json",
+      "fields": [{
+        "type": "text",
+        "name": "name",
+        "value": "Criterion 1"
+      }]
+    }],
+    "entities": [
+        {
+            "class": [
+                "criterion-cell"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "Proper use of grammar",
+                        "html": "Proper use of grammar"
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/3.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json
@@ -1,0 +1,53 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "Proper use of grammar",
+                "html": "Proper use of grammar"
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json
@@ -1,0 +1,53 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json
@@ -1,0 +1,53 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/3.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/3.json
@@ -1,0 +1,53 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/3.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json
@@ -1,0 +1,252 @@
+{
+    "class": [
+        "criterion"
+    ],
+    "properties": {
+        "name": "Criterion 2"
+    },
+    "entities": [
+        {
+            "class": [
+                "criterion-cell"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/0.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/1.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/2.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/3.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/0.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/0.json
@@ -1,0 +1,53 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/0.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/1.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/1.json
@@ -1,0 +1,53 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/1.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/2.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/2.json
@@ -1,0 +1,53 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/2.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/3.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/3.json
@@ -1,0 +1,53 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/3.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json
@@ -1,0 +1,252 @@
+{
+    "class": [
+        "criterion"
+    ],
+    "properties": {
+        "name": "Criterion 3"
+    },
+    "entities": [
+        {
+            "class": [
+                "criterion-cell"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/0.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/1.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/2.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/3.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/0.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/0.json
@@ -1,0 +1,53 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/0.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/1.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/1.json
@@ -1,0 +1,53 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/1.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/2.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/2.json
@@ -1,0 +1,53 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/2.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/3.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/3.json
@@ -1,0 +1,53 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/3.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/levels.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/levels.json
@@ -1,0 +1,165 @@
+{
+    "class": [
+        "collection",
+        "levels"
+    ],
+    "properties": {
+        "total": 4
+    },
+    "entities": [
+        {
+            "class": [
+                "level"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "properties": {
+                "name": "Level 4",
+                "points": 0.0
+            },
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "next"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "level"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "properties": {
+                "name": "Level 3",
+                "points": 0.0
+            },
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "prev"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+                },
+                {
+                    "rel": [
+                        "next"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "level"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "properties": {
+                "name": "Level 2",
+                "points": 0.0
+            },
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "prev"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+                },
+                {
+                    "rel": [
+                        "next"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "level"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "properties": {
+                "name": "Level 1",
+                "points": 0.0
+            },
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "prev"
+                    ],
+                    "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json
@@ -1,0 +1,29 @@
+{
+    "class": [
+        "level"
+    ],
+    "properties": {
+        "name": "Level 4",
+        "points": 0.0
+    },
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "next"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json
@@ -1,0 +1,35 @@
+{
+    "class": [
+        "level"
+    ],
+    "properties": {
+        "name": "Level 3",
+        "points": 0.0
+    },
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "prev"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+        },
+        {
+            "rel": [
+                "next"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json
@@ -1,0 +1,35 @@
+{
+    "class": [
+        "level"
+    ],
+    "properties": {
+        "name": "Level 2",
+        "points": 0.0
+    },
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "prev"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+        },
+        {
+            "rel": [
+                "next"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+        }
+    ]
+}

--- a/demo/static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json
+++ b/demo/static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json
@@ -1,0 +1,35 @@
+{
+    "class": [
+        "level"
+    ],
+    "properties": {
+        "name": "Level 1",
+        "points": 0.0
+    },
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1479.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "prev"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1477.json"
+        },
+        {
+            "rel": [
+                "next"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1478.json"
+        }
+    ]
+}

--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -93,6 +93,10 @@
 				'_onEntityChanged(entity)',
 			],
 
+			ready: function() {
+				this.addEventListener('d2l-rubric-entity-save-error', this._handleSaveError.bind(this));
+			},
+
 			_onEntityChanged: function(entity) {
 				if (!entity) {
 					return;

--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -19,6 +19,10 @@
 				box-sizing: border-box;
 			}
 
+			d2l-alert {
+				margin-bottom: 1rem;
+			}
+
 			.criteria-group {
 				border: var(--d2l-table-border);
 				border-radius: var(--d2l-table-border-radius);
@@ -46,6 +50,12 @@
 				padding: 1rem;
 			}
 		</style>
+
+		<template is="dom-repeat" items="[[_alerts]]">
+			<d2l-alert type="[[item.alertType]]" has-close-button>
+				[[item.alertMessage]]
+			</d2l-alert>
+		</template>
 
 		<d2l-rubric-loading hidden$="[[_showContent]]"></d2l-rubric-loading>
 
@@ -104,7 +114,11 @@
 
 			_hasOutOf: function(entity) {
 				return entity && entity.hasClass(this.HypermediaClasses.rubrics.numeric);
-			}
+			},
+
+			_handleSaveError: function(e) {
+				this._addAlert('error', e.detail.error.message, this.localize('rubricSavingErrorMessage'))
+			},
 		});
 	</script>
 </dom-module>

--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -117,7 +117,8 @@
 			},
 
 			_handleSaveError: function(e) {
-				this._addAlert('error', e.detail.error.message, this.localize('rubricSavingErrorMessage'))
+				this._clearAlerts();
+				this._addAlert('error', e.detail.error.message, this.localize('rubricSavingErrorMessage'));
 			},
 		});
 	</script>

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -94,6 +94,7 @@
 
 		<div class="cell col-first criterion-name">
 			<d2l-textarea
+				id="criterion-name"
 				aria-label="criterion name"
 				no-border
 				hover-styles
@@ -164,10 +165,12 @@
 					fields.append('name', e.target.value);
 					this.performSirenAction(action, fields).then(function() {
 						this.fire('d2l-rubric-criterion-saved');
+					}.bind(this)).catch(function() {
+						this.$$('#criterion-name').value = action.hasFieldByName('name') ? action.getFieldByName('name').value : '';
+						this.$$('#criterion-name').setAttribute('aria-invalid', true);
 					}.bind(this));
 				}
 			},
-
 		});
 	</script>
 </dom-module>

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -166,8 +166,7 @@
 					this.performSirenAction(action, fields).then(function() {
 						this.fire('d2l-rubric-criterion-saved');
 					}.bind(this)).catch(function() {
-						this.$$('#criterion-name').value = action.hasFieldByName('name') ? action.getFieldByName('name').value : '';
-						this.$$('#criterion-name').setAttribute('aria-invalid', true);
+						this.$$('#criterion-name').ariaInvalid = "true";
 					}.bind(this));
 				}
 			},

--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -116,6 +116,10 @@ Creates and edits a rubric
 				'_onEntityChanged(entity)'
 			],
 
+			ready: function() {
+				this.addEventListener('d2l-rubric-entity-error', this._handleError.bind(this));
+			},
+
 			_onEntityChanged: function(entity) {
 				if (entity && entity.hasLinkByRel(this.HypermediaRels.Rubrics.criteriaGroups)) {
 					this._showContent = true;

--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -130,11 +130,17 @@ Creates and edits a rubric
 			_hasOutOf: function(entity) {
 				return entity && entity.properties.outOf;
 			},
+
 			_hideLoading: function(showContent, hasAlerts) {
 				return showContent || hasAlerts;
 			},
+
 			_hideOutOf: function(showContent, hasAlerts) {
 				return !showContent || hasAlerts;
+			},
+
+			_handleError: function(e) {
+				this._addAlert('error', e.detail.error.message, this.localize('rubricLoadingErrorMessage'))
 			}
 		});
 	</script>

--- a/lang/ar.html
+++ b/lang/ar.html
@@ -28,6 +28,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'rubricLoadingErrorMessage': 'عذرًا، تعذّر علينا عرض آلية التقييم.',
+			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'يسرد هذا الجدول أسماء المعايير وأسماء مجموعات المعايير في العمود الأول. يسرد الصف الأول أسماء المستويات ويحتوي مجموع الدرجات إذا كانت آلية التقييم تستخدم طريقة رقمية لتسجيل النقاط.',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': 'المجموع'

--- a/lang/de.html
+++ b/lang/de.html
@@ -28,6 +28,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'rubricLoadingErrorMessage': 'Das Bewertungsschema konnte leider nicht angezeigt werden.',
+			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'In der ersten Spalte dieser Tabelle wird der Name der Kriterien und Kriteriengruppen aufgeführt. Die erste Zeile enthält die Namen der Niveaus sowie Punktzahlen, sofern für das Bewertungsschema eine numerische Bewertungsmethode verwendet wird.',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': 'Insgesamt'

--- a/lang/en.html
+++ b/lang/en.html
@@ -27,6 +27,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'rubricLoadingErrorMessage': 'Sorry, we were unable to display the rubric.',
+			'rubricSavingErrorMessage': 'Oops, something went wrong, please check your rubric.',
 			'rubricSummaryA11y': 'This table lists criteria and criteria group name in the first column. The first row lists level names and includes scores if the rubric uses a numeric scoring method.',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': 'Total'

--- a/lang/en.html
+++ b/lang/en.html
@@ -28,7 +28,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'rubricLoadingErrorMessage': 'Sorry, we were unable to display the rubric.',
-			'rubricSavingErrorMessage': 'Oops, something went wrong, please check your rubric.',
+			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'This table lists criteria and criteria group name in the first column. The first row lists level names and includes scores if the rubric uses a numeric scoring method.',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': 'Total'

--- a/lang/es.html
+++ b/lang/es.html
@@ -28,6 +28,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'rubricLoadingErrorMessage': 'Lo sentimos, no pudimos mostrar la rúbrica.',
+			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'Esta tabla muestra los nombres de los criterios y de los grupos de criterios en la primera columna. La primera fila muestra los nombres de los niveles e incluye las puntuaciones si la rúbrica usa un método de puntuación numérico.',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': 'Total'

--- a/lang/fr.html
+++ b/lang/fr.html
@@ -28,6 +28,7 @@
 			'predefinedFeedback': 'Predefined Feedback',
 			'percentage': '{number} %',
 			'rubricLoadingErrorMessage': 'Désolé, impossible d\'afficher la rubrique.',
+			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'Ce tableau comprend les critères et le nom du groupe de critères dans la première colonne. La première rangée contient les noms de niveau et comprend des pointages si la rubrique utilise une méthode de pointage numérique.',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': 'Total'

--- a/lang/ja.html
+++ b/lang/ja.html
@@ -28,6 +28,7 @@
 			'percentage': '{number} ％',
 			'predefinedFeedback': 'Predefined Feedback',
 			'rubricLoadingErrorMessage': '申し訳ありません。注釈を表示できませんでした。',
+			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'この表では 1 列目に条件と条件グループの名前が表示されます。注釈で数値によるスコアリング方法が使用されている場合、1 列目にはレベルが表示され、スコアが記載されます。',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': '合計'

--- a/lang/ko.html
+++ b/lang/ko.html
@@ -28,6 +28,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'rubricLoadingErrorMessage': '죄송합니다, 루브릭을 표시할 수 없습니다.',
+			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': '이 표에는 첫 번째 열에 기준 및 기준 그룹 이름이 나열됩니다. 루브릭이 숫자 점수 산정법을 사용할 경우, 첫 번째 행에 수준 이름이 나열되고 점수가 포함됩니다.',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': '총'

--- a/lang/nl.html
+++ b/lang/nl.html
@@ -28,6 +28,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'rubricLoadingErrorMessage': 'We kunnen de rubric niet weergeven.',
+			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'In de eerste kolom van deze tabel staan de criteria en de criteriagroepnaam. In de eerste rij staan de niveaunamen en eventueel de scores als de rubric gebruikmaakt van een numerieke scoremethode.',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': 'Totaal'

--- a/lang/pt.html
+++ b/lang/pt.html
@@ -28,6 +28,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'rubricLoadingErrorMessage': 'Infelizmente, não foi possível exibir a rubrica.',
+			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'A tabela lista critérios e nomes de grupos de critérios na primeira coluna. A primeira linha lista nomes de nível e inclui pontuações caso a rubrica use um método de pontuação numérica.',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': 'Total'

--- a/lang/sv.html
+++ b/lang/sv.html
@@ -28,6 +28,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'rubricLoadingErrorMessage': 'Tyvärr, vi kunde inte visa rubricering.',
+			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'Denna tabell innehåller kriterier och namn på kriteriegrupp i den första kolumnen. På den första raden listas nivånamn och betyg inkluderas om rubriceringen använder en numerisk betygsättningsmetod.',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': 'Totalt'

--- a/lang/tr.html
+++ b/lang/tr.html
@@ -28,6 +28,7 @@
 			'percentage': '%{number}',
 			'predefinedFeedback': 'Predefined Feedback',
 			'rubricLoadingErrorMessage': 'Üzgünüz; rubrik görüntülenemedi.',
+			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'Bu tablo, ilk sütundaki kriter ve kriter grubu adlarını listeler. İlk satır seviye adlarını listeler ve rubrik sayısal bir puanlama yöntemi kullanıyorsa puanları içerir.',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': 'Toplam'

--- a/lang/zh-tw.html
+++ b/lang/zh-tw.html
@@ -28,6 +28,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'rubricLoadingErrorMessage': '抱歉，我們無法顯示量規。',
+			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': '此表格會在第一欄列出標準和標準群組名稱。第一列會列出層級名稱並包含分數 (如果量規使用數字評分方法)。',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': '總計'

--- a/lang/zh.html
+++ b/lang/zh.html
@@ -28,6 +28,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'rubricLoadingErrorMessage': '抱歉，我们无法显示量规。',
+			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': '此表第一列中列出了标准和标准组名。第一行列出了级别名称；如果量规使用数字评分方法，则还包括分数。',
 			'scoreOutOf': '{score} /\u00A0{outOf}',
 			'total': '总计'

--- a/store/entity-editor-behavior.html
+++ b/store/entity-editor-behavior.html
@@ -58,8 +58,6 @@
 
 		ready: function() {
 			this._entityChangedHandler = this._entityChanged.bind(this);
-			this.addEventListener('d2l-rubric-entity-error', this._handleError.bind(this))
-			this.addEventListener('d2l-rubric-entity-save-error', this._handleSaveError.bind(this))
 		},
 
 		detached: function() {
@@ -97,12 +95,6 @@
 				return entity.href || (entity.hasLinkByRel('self') ? entity.getLinkByRel('self').href : '');
 			}
 			return '';
-		},
-
-		_handleError: function(e) {
-		},
-
-		_handleSaveError: function(e) {
 		},
 
 		_addAlert: function(type, name, message) {

--- a/store/entity-editor-behavior.html
+++ b/store/entity-editor-behavior.html
@@ -50,7 +50,6 @@
 				type: Boolean,
 				value: false
 			}
-
 		},
 
 		observers: [
@@ -59,6 +58,8 @@
 
 		ready: function() {
 			this._entityChangedHandler = this._entityChanged.bind(this);
+			this.addEventListener('d2l-rubric-entity-error', this._handleError.bind(this))
+			this.addEventListener('d2l-rubric-entity-save-error', this._handleSaveError.bind(this))
 		},
 
 		detached: function() {
@@ -82,9 +83,13 @@
 			}
 		},
 
-		_entityChanged: function(entity) {
-			this.entity = entity;
-			this.fire('d2l-rubric-entity-changed', {entity: entity});
+		_entityChanged: function(entity, error) {
+			if (!error) {
+				this.entity = entity;
+				this.fire('d2l-rubric-entity-changed', { entity: entity });
+			} else {
+				this.fire('d2l-rubric-entity-error', { error: error })
+			}
 		},
 
 		_getSelfLink: function(entity) {
@@ -94,6 +99,27 @@
 			return '';
 		},
 
+		_handleError: function(e) {
+		},
+
+		_handleSaveError: function(e) {
+		},
+
+		_addAlert: function(type, name, message) {
+			if (this._alerts) {
+				this.push('_alerts', {
+					alertType: type,
+					alertName: name,
+					alertMessage: message
+				});
+				this._hasAlerts = true;
+			}
+		},
+
+		_computeHasAlerts: function(_alerts) {
+			console.log(this._alerts);
+			return _alerts.length > 0;
+		}
 	};
 
 	/** @polymerBehavior */

--- a/store/entity-editor-behavior.html
+++ b/store/entity-editor-behavior.html
@@ -107,19 +107,26 @@
 
 		_addAlert: function(type, name, message) {
 			if (this._alerts) {
-				this.push('_alerts', {
-					alertType: type,
-					alertName: name,
-					alertMessage: message
-				});
-				this._hasAlerts = true;
+				// Something weird happens when clearing alerts immediately before
+				// adding alerts and the dom-repeat seems to get stuck and doesn't display
+				// new alerts. So adding new alerts async
+				setTimeout(function() {
+					this.push('_alerts', {
+						alertType: type,
+						alertName: name,
+						alertMessage: message
+					});
+					// Also trying to set _hasAlerts as a computed property based on _alerts
+					// also does not seem to be working reliably so having to manage it manually.
+					this._hasAlerts = true;
+				}.bind(this));
 			}
 		},
 
-		_computeHasAlerts: function(_alerts) {
-			console.log(this._alerts);
-			return _alerts.length > 0;
-		}
+		_clearAlerts: function() {
+			this.splice('_alerts', 0, this._alerts.length);
+			this._hasAlerts = false;
+		},
 	};
 
 	/** @polymerBehavior */

--- a/store/siren-action-behavior.html
+++ b/store/siren-action-behavior.html
@@ -81,10 +81,12 @@
 			})
 			.then(function (res) {
 				if (!res.ok) {
-					throw new Error(`${ res.statusText } response executing ${ action.method } on ${ url.href }.`);
+					const error = new Error(`${ res.statusText } response executing ${ action.method } on ${ url.href }.`);
+					this.fire('d2l-rubric-entity-save-error', { error: error });
+					throw error;
 				}
 				return res.json();
-			})
+			}.bind(this))
 			.then(function(body) {
 				var entity = window.D2L.Hypermedia.Siren.Parse(body);
 				return window.D2L.Rubric.EntityStore.update(url.href, token, entity);

--- a/test/components/d2l-rubric-criterion-editor.js
+++ b/test/components/d2l-rubric-criterion-editor.js
@@ -66,7 +66,7 @@ suite('<d2l-rubric-criterion-editor>', function() {
 				});
 			});
 
-			test.only('sets aria-invalid if saving name fails', function(done) {
+			test('sets aria-invalid if saving name fails', function(done) {
 				fetch = sinon.stub(window.d2lfetch, 'fetch');
 				var promise = Promise.resolve({
 					ok: false,

--- a/test/components/d2l-rubric-criterion-editor.js
+++ b/test/components/d2l-rubric-criterion-editor.js
@@ -1,4 +1,4 @@
-/* global suite, test, fixture, expect, setup, teardown, suiteSetup, suiteTeardown, sinon */
+/* global suite, test, fixture, expect, setup, teardown, suiteSetup, suiteTeardown, sinon, flush */
 
 'use strict';
 
@@ -56,13 +56,36 @@ suite('<d2l-rubric-criterion-editor>', function() {
 				var nameTextArea = element.$$('d2l-textarea');
 				nameTextArea.value = 'Batman and Robin';
 				raf(function() {
-					nameTextArea.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: false, composed: true }));
 					element.addEventListener('d2l-rubric-criterion-saved', function() {
 						var body = fetch.args[0][1].body;
 						// Force success in IE - no FormData op support
 						expect(body.get && body.get('name') || 'Batman and Robin').to.equal('Batman and Robin');
 						done();
 					});
+					nameTextArea.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: false, composed: true }));
+				});
+			});
+
+			test.only('sets aria-invalid if saving name fails', function(done) {
+				fetch = sinon.stub(window.d2lfetch, 'fetch');
+				var promise = Promise.resolve({
+					ok: false,
+					json: function() {
+						return Promise.resolve(JSON.stringify({}));
+					}
+				});
+				fetch.returns(promise);
+
+				var nameTextArea = element.$$('d2l-textarea');
+				nameTextArea.value = 'Batman and Robin';
+				raf(function() {
+					element.addEventListener('d2l-rubric-entity-save-error', function() {
+						flush(function() {
+							expect(nameTextArea.ariaInvalid).to.equal('true');
+							done();
+						});
+					});
+					nameTextArea.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: false, composed: true }));
 				});
 			});
 		});


### PR DESCRIPTION
Included error events for loading/saving and added event listeners at appropriate levels in the component hierarchy to render `d2l-alerts` in response to the errors.

Load errors are currently handled by the `d2l-rubric-editor` component.
Criterion name save errors are handled by the `d2l-rubric-criterion-group-editor`.

In addition to dispatching the `d2l-rubric-entity-save-error` event, the criterion editor handles the rejected promise from the call to perform the siren action by setting the `ariaInvalid` property of the name textarea that could not be saved.

Note the save event is handled at a different level in the hierarchy to the criterion name. My reasoning is that the it probably makes most sense to show errors saving names/descriptions etc above the associated criterion group rather than above the complete rubric, as for a rubric with multiple groups, that will likely be off-screen.

Main changes of interest are in:

- d2l-rubric-editor.html
- d2l-rubric-criteria-group-editor.html
- d2l-rubric-criterion-editor.html
- entity-editor-behavior.html
- siren-action-behavior.html

Most of the files in this commit are static-data files I added for the demo pages, similar to those I added for the unit tests. This is just so the action is present and can be used to show an error in the demo pages. Once we have more of the API implemented to include actions in the read APIs we can possibly remove these static data files.