### PR TITLE
Mbayly/add experimental criterion animation

### DIFF
--- a/demo/d2l-rubric-editor.html
+++ b/demo/d2l-rubric-editor.html
@@ -48,7 +48,7 @@
 		<d2l-rubric-editor href="data/rubrics/organizations/text-only/199.json" token="foozleberries"></d2l-rubric-editor>
 	</demo-snippet>
 
-	<h3>Rubric with a title</h3>
+	<!-- <h3>Rubric with a title</h3>
 	<demo-snippet>
 		<d2l-rubric-editor href="data/rubrics/organizations/default-rubric/197.json" token="foozleberries">
 			<h3 class="rubric-title">
@@ -80,7 +80,7 @@
 	<h3>Rubric loading</h3>
 	<demo-snippet>
 		<d2l-rubric-loading></d2l-rubric-loading>
-	</demo-snippet>
+	</demo-snippet> -->
 
 </div>
 </body>

--- a/demo/d2l-rubric-editor.html
+++ b/demo/d2l-rubric-editor.html
@@ -48,7 +48,7 @@
 		<d2l-rubric-editor href="data/rubrics/organizations/text-only/199.json" token="foozleberries"></d2l-rubric-editor>
 	</demo-snippet>
 
-	<!-- <h3>Rubric with a title</h3>
+	<h3>Rubric with a title</h3>
 	<demo-snippet>
 		<d2l-rubric-editor href="data/rubrics/organizations/default-rubric/197.json" token="foozleberries">
 			<h3 class="rubric-title">
@@ -80,7 +80,7 @@
 	<h3>Rubric loading</h3>
 	<demo-snippet>
 		<d2l-rubric-loading></d2l-rubric-loading>
-	</demo-snippet> -->
+	</demo-snippet>
 
 </div>
 </body>

--- a/editor/d2l-rubric-criteria-editor.html
+++ b/editor/d2l-rubric-criteria-editor.html
@@ -71,19 +71,27 @@
 				D2L.PolymerBehaviors.Rubric.LocalizeBehavior
 			],
 
-			observers: [
-				'_onEntityChanged(entity)',
-			],
-
-			_onEntityChanged: function(entity) {
+			_onEntityChanged: function(entity, oldEntity) {
 				if (!entity) {
 					return;
 				}
 				this._criteriaEntities = entity.getSubEntitiesByClass(this.HypermediaClasses.rubrics.criterion);
-				this.animating = false;
-				Polymer.RenderStatus.afterNextRender(this, function() {
-					this.animating = false;
-				}.bind(this));
+				// EXPERIMENTAL animation/transition handling. If oldEntity is undefined, then
+				// this represents the initial render so indicate to child components that we
+				// are animating so that child components don't animate on initial render.
+				// After render, reset the animation flag so that subsequently added criterion will animate.
+
+				// NOTE: this is experimental and will not support use cases where an entity is inserted into
+				// an existing list, in which case the oldEntity will be the entity that was previously
+				// rendered by this component. Once we have that scenario we may have to store state with
+				// each entity to indicate whether it was just newly created (should potentially animate) or
+				// was simply updated.
+				if (!oldEntity) {
+					this.animating = true;
+					Polymer.RenderStatus.afterNextRender(this, function() {
+						this.animating = false;
+					}.bind(this));
+				}
 			},
 
 			_getCriterionLegend: function(index, count) {

--- a/editor/d2l-rubric-criteria-editor.html
+++ b/editor/d2l-rubric-criteria-editor.html
@@ -31,12 +31,14 @@
 			fieldset:last-of-type {
 				border-bottom: none;
 			}
+
 		</style>
 
 		<template is="dom-repeat" items="[[_criteriaEntities]]" as="criterion" rendered-item-count="{{criterionCount}}" >
 			<fieldset>
 				<legend><d2l-offscreen>[[_getCriterionLegend(index, criterionCount)]]</d2l-offscreen></legend>
 				<d2l-rubric-criterion-editor
+					animating="[[animating]]"
 					href="[[_getSelfLink(criterion)]]"
 					token="[[token]]"
 					has-out-of="[[hasOutOf]]"
@@ -54,6 +56,10 @@
 			properties: {
 				_criteriaEntities: Array,
 				hasOutOf: {
+					type: Boolean,
+					value: false
+				},
+				animating: {
 					type: Boolean,
 					value: false
 				}
@@ -74,6 +80,10 @@
 					return;
 				}
 				this._criteriaEntities = entity.getSubEntitiesByClass(this.HypermediaClasses.rubrics.criterion);
+				this.animating = false;
+				Polymer.RenderStatus.afterNextRender(this, function() {
+					this.animating = false;
+				}.bind(this));
 			},
 
 			_getCriterionLegend: function(index, count) {

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -22,12 +22,21 @@
 				justify-content: space-between;
 				overflow: hidden;
 
+				opacity: 0;
+				max-height: 0;
+				transition: opacity 10000ms ease-out, max-height 5000ms ease-out;
+
 				--d2l-textarea: {
 					display: block;
 					height: 100%;
 					overflow: hidden;
 					hyphens: auto;
 				};
+			}
+
+			:host(.show) {
+				max-height: none;
+				opacity: 1;
 			}
 
 			* {
@@ -167,6 +176,10 @@
 				displayNamePlaceholder: {
 					type: Boolean,
 				},
+				animating: {
+					type: Boolean,
+					value: false
+				}
 			},
 
 			behaviors: [
@@ -175,6 +188,26 @@
 				window.D2L.Hypermedia.HMConstantsBehavior,
 				D2L.PolymerBehaviors.Rubric.LocalizeBehavior
 			],
+
+			observers: [
+				'_onEntityChanged(entity)',
+			],
+
+			_onEntityChanged: function(entity) {
+				if (!entity) {
+					return;
+				}
+				// Polymer.RenderStatus.afterNextRender(this, function() {
+				// 	this._transitionElement(this);
+				// });
+				if (!this.animating) {
+					setTimeout(function() {
+						this._transitionElement(this, 200);
+					}.bind(this));
+				} else {
+					this.className = this.className + " show";
+				}
+			},
 
 			_getCriterionCells: function(entity) {
 				var entities = entity && entity.getSubEntitiesByClass(this.HypermediaClasses.rubrics.criterionCell);

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -24,7 +24,7 @@
 
 				opacity: 0;
 				max-height: 0;
-				transition: opacity 10000ms ease-out, max-height 5000ms ease-out;
+				transition: opacity 100ms ease-out, max-height 400ms ease-out;
 
 				--d2l-textarea: {
 					display: block;
@@ -189,18 +189,11 @@
 				D2L.PolymerBehaviors.Rubric.LocalizeBehavior
 			],
 
-			observers: [
-				'_onEntityChanged(entity)',
-			],
-
-			_onEntityChanged: function(entity) {
+			_onEntityChanged: function(entity, oldEntity) {
 				if (!entity) {
 					return;
 				}
-				// Polymer.RenderStatus.afterNextRender(this, function() {
-				// 	this._transitionElement(this);
-				// });
-				if (!this.animating) {
+				if (!this.animating && !oldEntity) {
 					setTimeout(function() {
 						this._transitionElement(this, 200);
 					}.bind(this));

--- a/store/entity-editor-behavior.html
+++ b/store/entity-editor-behavior.html
@@ -91,6 +91,10 @@
 			}
 		},
 
+		_onEntityChanged: function(entity, oldEntity) {
+			// default empty implementation
+		},
+
 		_getSelfLink: function(entity) {
 			if (entity) {
 				return entity.href || (entity.hasLinkByRel('self') ? entity.getLinkByRel('self').href : '');

--- a/store/entity-editor-behavior.html
+++ b/store/entity-editor-behavior.html
@@ -1,5 +1,5 @@
 <script>
-	'use strict';
+	// 'use strict';
 
 	window.D2L = window.D2L || {};
 	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
@@ -119,6 +119,21 @@
 			this.splice('_alerts', 0, this._alerts.length);
 			this._hasAlerts = false;
 		},
+
+		_transitionElement: function(element, maxHeight) {
+
+			element.style.maxHeight = maxHeight + 'px';
+			element.className = element.className + " show";
+
+			// when the next css transition finishes (which should be the one we just triggered)
+			element.addEventListener('transitionend', function(e) {
+				// remove this event listener so it only gets triggered once
+				element.removeEventListener('transitionend', arguments.callee);
+
+				// remove "max-height" from the element's inline styles, so it can return to its initial value
+				element.style.maxHeight = null;
+			});
+		}
 	};
 
 	/** @polymerBehavior */

--- a/store/entity-editor-behavior.html
+++ b/store/entity-editor-behavior.html
@@ -31,7 +31,8 @@
 			 */
 			entity: {
 				type: Object,
-				value: null
+				value: null,
+				observer: '_onEntityChanged',
 			},
 
 			_entityChangedHandler: {
@@ -123,7 +124,7 @@
 		_transitionElement: function(element, maxHeight) {
 
 			element.style.maxHeight = maxHeight + 'px';
-			element.className = element.className + " show";
+			element.classList.add('show');
 
 			// when the next css transition finishes (which should be the one we just triggered)
 			element.addEventListener('transitionend', function(e) {


### PR DESCRIPTION
This is just putting in place some building blocks to enable animation when we implement the add criterion story.

The difficulty for us for in implementing animation is that we are relying on the hypermedia responses and the automatic re-rendering to generate the UI changes in response to actions, so it would be circumventing that if we were to manage the animations manually. 

So this change puts in place some controls/logic for determining when a new entity (in this case a criterion) is rendered and hence is a candidate for a CSS transition.

I've also added the foundation for an opacity/height based animation for the criterion.

Animating this stuff is tricky as described in this blog post, because we want the height of a criterion to be dynamic and you cannot animate to an auto value.  I've opted for a variation of two of the techiques described in the blog post, setting a default max height and then animating to that height, then removing the max-height after the animation completes.  This might work reasonably well for an empty criterion, although it might become more problematic when we make the feedback display optional.

https://css-tricks.com/using-css-transitions-auto-dimensions/

I've also added support for a parent element to indicate to child components that the parent is animating so the children should not.

This is the not so clearly named `animating` property. If this is passed to a child component with the value true, it means the parent is animating so even if the child thinks it is a new entity, it should not animate.  This is partly to prevent the criterion from animating when they are first rendered, but could also be useful in other scenarios.

I think this stuff is going to get even more tricky/problematic when we try and animate levels as that affects multiple components, and the simple approach I'm using here of animating when the observed entity changes from undefined to defined, won't work so well because a polymer component might be used to render a different but newly added entity e..g if inserting into a list.