### PR TITLE
Use the onEntityChange override instead, this was causing the behavio…

### DIFF
--- a/d2l-rubric-criteria-group.html
+++ b/d2l-rubric-criteria-group.html
@@ -161,12 +161,11 @@
 			],
 
 			observers: [
-				'_entityChanged(entity)',
 				'_onLevelsEntityChanged(_levelsEntity)',
 				'_onCriteriaCollectionEntityChanged(_criteriaCollectionEntity)'
 			],
 
-			_entityChanged: function(entity) {
+			_onEntityChanged: function(entity) {
 				if (!entity) {
 					return;
 				}


### PR DESCRIPTION
…r entityChanged method to not be called