### PR TITLE
Fix demo pages in all browsers

### DIFF
--- a/demo/d2l-rubric-editor.html
+++ b/demo/d2l-rubric-editor.html
@@ -50,7 +50,7 @@
 		<d2l-rubric-editor href="data/rubrics/organizations/text-only/199.json" token="foozleberries"></d2l-rubric-editor>
 	</demo-snippet>
 
-	<!-- <h3>Rubric with a title</h3>
+	<h3>Rubric with a title</h3>
 	<demo-snippet>
 		<d2l-rubric-editor href="data/rubrics/organizations/default-rubric/197.json" token="foozleberries">
 			<h3 class="rubric-title">
@@ -87,7 +87,7 @@
 	<h3>Rubric loading</h3>
 	<demo-snippet>
 		<d2l-rubric-loading></d2l-rubric-loading>
-	</demo-snippet> -->
+	</demo-snippet>
 
 </div>
 </body>

--- a/demo/d2l-rubric-editor.html
+++ b/demo/d2l-rubric-editor.html
@@ -21,14 +21,11 @@
 
 	<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 	<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+	<link rel="import" href="../../d2l-typography/d2l-typography.html">
+	<link rel="import" href="../../d2l-fetch-siren-entity-behavior/d2l-fetch-siren-entity-behavior.html">
+	<link rel="import" href="./fetch-siren-entity-whitelist.html">
 	<link rel="import" href="../editor/d2l-rubric-editor.html">
 	<link rel="import" href="../d2l-rubric-title.html">
-	<link rel="import" href="../../d2l-typography/d2l-typography.html">
-
-	<script>
-		'use strict';
-		(D2L.PolymerBehaviors.FetchSirenEntityBehavior || {})._isWhitelisted = function() { return true; };
-	</script>
 
 	<style is="custom-style" include="demo-pages-shared-styles">
 	</style>
@@ -53,7 +50,7 @@
 		<d2l-rubric-editor href="data/rubrics/organizations/text-only/199.json" token="foozleberries"></d2l-rubric-editor>
 	</demo-snippet>
 
-	<h3>Rubric with a title</h3>
+	<!-- <h3>Rubric with a title</h3>
 	<demo-snippet>
 		<d2l-rubric-editor href="data/rubrics/organizations/default-rubric/197.json" token="foozleberries">
 			<h3 class="rubric-title">
@@ -90,7 +87,7 @@
 	<h3>Rubric loading</h3>
 	<demo-snippet>
 		<d2l-rubric-loading></d2l-rubric-loading>
-	</demo-snippet>
+	</demo-snippet> -->
 
 </div>
 </body>

--- a/demo/fetch-siren-entity-whitelist.html
+++ b/demo/fetch-siren-entity-whitelist.html
@@ -1,0 +1,6 @@
+<script>
+	'use strict';
+	(D2L.PolymerBehaviors.FetchSirenEntityBehavior || {})._isWhitelisted = function() {
+		return true;
+	};
+</script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,14 +21,11 @@
 
 	<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 	<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+	<link rel="import" href="../../d2l-fetch-siren-entity-behavior/d2l-fetch-siren-entity-behavior.html">
+	<link rel="import" href="./fetch-siren-entity-whitelist.html">
 	<link rel="import" href="../d2l-rubric.html">
 	<link rel="import" href="../d2l-rubric-title.html">
 	<link rel="import" href="../../d2l-typography/d2l-typography.html">
-
-	<script>
-		'use strict';
-		(D2L.PolymerBehaviors.FetchSirenEntityBehavior || {})._isWhitelisted = function() { return true; };
-	</script>
 
 	<style is="custom-style" include="demo-pages-shared-styles">
 	</style>


### PR DESCRIPTION
We  were finding that the demo page fix for the siren fetch whitelisting was not working correctly in all browsers due to differences in how browsers handle inline script vs script in html imports.  The inline script to override the whitelist method was executing before the siren fetch behavior was loaded, causing null reference exceptions.

So moved the stub to an html import and explicitly import siren fetch into the demo pages to make sure things are loaded consistently.