### PR TITLE
Call delete criterion API and animate

### DIFF
--- a/editor/d2l-rubric-criteria-editor.html
+++ b/editor/d2l-rubric-criteria-editor.html
@@ -26,18 +26,9 @@
 				margin: 0;
 			}
 
-			fieldset {
-				border-bottom: var(--d2l-table-border);
-			}
-
-			fieldset:last-of-type {
-				border-bottom: none;
-			}
-
 			.footer {
 				border-bottom-left-radius: var(--d2l-table-border-radius);
 				border-bottom-right-radius: var(--d2l-table-border-radius);
-				border-top: var(--d2l-table-border);
 				text-align: center;
 				padding: 1rem;
 			}

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -23,7 +23,7 @@
 				flex-direction: row;
 				justify-content: space-between;
 				background-color: white;
-
+				border: 0;
 				opacity: 0;
 				max-height: 0;
 				transition: opacity 100ms ease-out, max-height 400ms ease-out;
@@ -39,6 +39,7 @@
 			:host(.show) {
 				max-height: none;
 				opacity: 1;
+				border-bottom: var(--d2l-table-border);
 			}
 
 			* {
@@ -172,6 +173,7 @@
 				hidden$="[[!_showRemove(entity, moreThanOneCriterion)]]"
 				icon="d2l-tier1:delete"
 				text="[[localize('removeCriterion')]]"
+				on-tap="_handleDeleteCriterion"
 			></d2l-button-icon>
 			<template is="dom-if" if="[[_showRemove(entity, moreThanOneCriterion)]]">
 				<d2l-tooltip for="remove" position="bottom">[[localize('removeCriterion')]]</d2l-tooltip>
@@ -303,6 +305,16 @@
 
 			_showRemove: function(entity, moreThanOneCriterion) {
 				return this._canDeleteCriterion(entity) && moreThanOneCriterion;
+			},
+
+			_handleDeleteCriterion: function() {
+				var action = this.entity.getActionByName('delete');
+				if (action) {
+					this._transitionElement(this, 0);
+					this.performSirenAction(action).then(function() {
+						this.fire('d2l-rubric-criterion-deleted');
+					}.bind(this));
+				}
 			}
 
 		});

--- a/store/entity-behavior.html
+++ b/store/entity-behavior.html
@@ -129,11 +129,17 @@
 		},
 
 		_transitionElement: function(element, maxHeightRem) {
-
-			fastdom.mutate(function() {
-				element.style.maxHeight = maxHeightRem + 'rem';
-				element.classList.add('show');
-			})
+			if (maxHeightRem) {
+				fastdom.mutate(function() {
+					element.style.maxHeight = maxHeightRem + 'rem';
+					element.classList.add('show');
+				});
+			} else {
+				fastdom.mutate(function() {
+					element.style.maxHeight = element.offsetHeight + 'px';
+					element.classList.remove('show');
+				});
+			}
 
 			// when the next css transition finishes (which should be the one we just triggered)
 			element.addEventListener('transitionend', function(e) {
@@ -143,7 +149,7 @@
 				// remove "max-height" from the element's inline styles, so it can return to its initial value
 				fastdom.mutate(function() {
 					element.style.maxHeight = null;
-				})
+				});
 			});
 		}
 	};

--- a/test/components/d2l-rubric-criteria-editor.js
+++ b/test/components/d2l-rubric-criteria-editor.js
@@ -44,7 +44,7 @@ suite('<d2l-rubric-criteria-editor>', function() {
 				window.D2L.Rubric.EntityStore.clear();
 			});
 
-			test.only('adds criterion', function(done) {
+			test('adds criterion', function(done) {
 				fetch = sinon.stub(window.d2lfetch, 'fetch');
 				var promise = Promise.resolve({
 					ok: true,

--- a/test/components/d2l-rubric-criterion-editor.js
+++ b/test/components/d2l-rubric-criterion-editor.js
@@ -160,7 +160,45 @@ suite('<d2l-rubric-criterion-editor>', function() {
 				var removeButton = element.$.remove;
 				expect(isVisible(removeButton)).to.be.true;
 			});
+		});
 
+		suite('remove criterion', function() {
+
+			var fetch;
+			var element;
+
+			setup(function(done) {
+				element = fixture('moreThanOneCriterion');
+				function waitForLoad(e) {
+					if (e.detail.entity.getLinkByRel('self').href === 'static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json') {
+						element.removeEventListener('d2l-rubric-entity-changed', waitForLoad);
+						done();
+					}
+				}
+				element.addEventListener('d2l-rubric-entity-changed', waitForLoad);
+				element.token = 'foozleberries';
+			});
+
+			teardown(function() {
+				fetch && fetch.restore();
+				window.D2L.Rubric.EntityStore.clear();
+			});
+
+			test('generates event if deleting fails', function(done) {
+				fetch = sinon.stub(window.d2lfetch, 'fetch');
+				var promise = Promise.resolve({
+					ok: false,
+					json: function() {
+						return Promise.resolve(JSON.stringify({}));
+					}
+				});
+				fetch.returns(promise);
+
+				element.addEventListener('d2l-rubric-entity-save-error', function() {
+					done();
+				});
+				element.$$('#remove').click();
+			});
 		});
 	});
 });


### PR DESCRIPTION
US97361 - Remove criterion from Rubric (UI)
- TA125984: Call Action when trashcan clicked
- TA125985: Animate the removal of criterion
- TA125986: Error handling    _(no code changes were required for this)_

1 Bug: 1. Delete a criterion. 2. Add a new criterion. Observe no animation on the new criterion.