### PR TITLE
Us97438 add level buttons

### DIFF
--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -103,6 +103,11 @@
 				width: 1.5rem;
 			}
 
+			.col-last-empty {
+				min-width: calc(1rem + 44px); /* button width = 44px including border */
+				flex: 0 0 0;
+			}
+
 			.criterion-remove {
 				position: absolute;
 				margin: 1rem 0;
@@ -166,6 +171,7 @@
 			</div>
 		</div>
 		<div hidden="[[!hasOutOf]]" class="cell col-last points">/ <d2l-text-input value="" aria-label="todo" prevent-submit></d2l-text-input></div>
+		<div hidden="[[hasOutOf]]" class="cell col-last-empty"></div>
 		<div class="criterion-remove">
 			<d2l-button-icon
 				id="remove"
@@ -173,9 +179,6 @@
 				icon="d2l-tier1:delete"
 				text="[[localize('removeCriterion')]]"
 			></d2l-button-icon>
-			<template is="dom-if" if="[[_showRemove(entity, moreThanOneCriterion)]]">
-				<d2l-tooltip for="remove" position="bottom">[[localize('removeCriterion')]]</d2l-tooltip>
-			</template>
 		</div>
 	</template>
 

--- a/editor/d2l-rubric-level-editor.html
+++ b/editor/d2l-rubric-level-editor.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../d2l-text-input/d2l-text-input.html">
 <link rel="import" href="../../d2l-tooltip/d2l-tooltip.html">
+<link rel="import" href="../../d2l-button/d2l-button-icon.html">
 
 <link rel="import" href="../store/entity-behavior.html">
 <link rel="import" href="../store/siren-action-behavior.html">
@@ -17,6 +18,18 @@
 				box-sizing: border-box;
 			}
 
+			.operations {
+				text-align: right;
+			}
+
+			:host-context([dir='rtl']) .operations {
+				text-align: left;
+			}
+
+			d2l-button-icon {
+				padding-top: 0.5rem;
+			}
+
 		</style>
 
 		<d2l-text-input
@@ -29,6 +42,14 @@
 			required="[[_nameRequired]]"
 			prevent-submit>
 		</d2l-text-input>
+		<div class="operations">
+			<d2l-button-icon
+				id="remove"
+				icon="d2l-tier1:delete"
+				text="[[localize('removeLevel')]]"
+				disabled>
+			</d2l-button-icon>
+		</div>
 		<template is="dom-if" if="[[_nameInvalid]]">
 			<d2l-tooltip for="level-name" position="bottom">[[_nameInvalidError]]</d2l-tooltip>
 		</template>

--- a/editor/d2l-rubric-levels-editor.html
+++ b/editor/d2l-rubric-levels-editor.html
@@ -44,7 +44,7 @@
 				align-items: center;
 				justify-content: flex-start;
 			}
-			.empty {
+			.col-last[noOutOf] {
 				min-width: calc(1rem + 44px); /* button width = 44px including border */
 				flex: 0 0 0;
 			}
@@ -56,7 +56,7 @@
 		<template is="dom-repeat" items="[[_levels]]" as="level">
 			<div class="cell"><d2l-rubric-level-editor href="[[_getSelfLink(level)]]" token="[[token]]"></d2l-rubric-level-editor></div>
 		</template>
-		<div class="cell col-last empty">
+		<div class="cell col-last" noOutOf$=[[!hasOutOf]]>
 			<d2l-button-icon icon="d2l-tier2:add" text=[[localize('addLevel')]]></d2l-button-icon>
 		</div>
 	</template>
@@ -81,7 +81,6 @@
 
 			observers: [
 				'_onEntityChanged(entity)',
-				'_onHasOutOfChanged(hasOutOf)',
 			],
 
 			_onEntityChanged: function(entity) {
@@ -90,11 +89,6 @@
 				}
 				this._levels = entity.getSubEntitiesByClass(this.HypermediaClasses.rubrics.level);
 			},
-			_onHasOutOfChanged: function(hasOutOf) {
-				if (hasOutOf) {
-					this.$$('.col-last').classList.remove('empty');
-				}
-			}
 		});
 	</script>
 </dom-module>

--- a/editor/d2l-rubric-levels-editor.html
+++ b/editor/d2l-rubric-levels-editor.html
@@ -56,7 +56,7 @@
 		<template is="dom-repeat" items="[[_levels]]" as="level">
 			<div class="cell"><d2l-rubric-level-editor href="[[_getSelfLink(level)]]" token="[[token]]"></d2l-rubric-level-editor></div>
 		</template>
-		<div class="cell col-last">
+		<div class="cell col-last empty">
 			<d2l-button-icon icon="d2l-tier2:add" text=[[localize('addLevel')]]></d2l-button-icon>
 		</div>
 	</template>
@@ -91,8 +91,8 @@
 				this._levels = entity.getSubEntitiesByClass(this.HypermediaClasses.rubrics.level);
 			},
 			_onHasOutOfChanged: function(hasOutOf) {
-				if (!hasOutOf) {
-					this.$$('.col-last').classList.add('empty');
+				if (hasOutOf) {
+					this.$$('.col-last').classList.remove('empty');
 				}
 			}
 		});

--- a/editor/d2l-rubric-levels-editor.html
+++ b/editor/d2l-rubric-levels-editor.html
@@ -1,8 +1,10 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../d2l-table/d2l-table-shared-styles.html">
 <link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
+<link rel="import" href="../../d2l-button/d2l-button-icon.html">
 
 <link rel="import" href="../store/entity-behavior.html">
+<link rel="import" href="../localize-behavior.html">
 <link rel="import" href="./d2l-rubric-level-editor.html">
 <link rel="import" href="./d2l-rubric-editor-cell-styles.html">
 
@@ -19,13 +21,44 @@
 			* {
 				box-sizing: border-box;
 			}
+			.cell {
+				padding: 0.5rem;
+			}
+			d2l-button-icon {
+				border-radius: 0.3rem;
+				border: 1px solid var(--d2l-color-mica);
+				background-color: var(--d2l-color-sylvite);
+				height: 100%;
+				align-items: center;
+				--d2l-button-icon-min-height: 100%;
+			}
+			.col-first {
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+				justify-content: flex-end;
+			}
+			.col-last {
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+				justify-content: flex-start;
+			}
+			.empty {
+				min-width: calc(1rem + 44px); /* button width = 44px including border */
+				flex: 0 0 0;
+			}
 		</style>
 
-		<div class="cell col-first"></div>
+		<div class="cell col-first">
+			<d2l-button-icon icon="d2l-tier2:add" text=[[localize('addLevel')]]></d2l-button-icon>
+		</div>
 		<template is="dom-repeat" items="[[_levels]]" as="level">
 			<div class="cell"><d2l-rubric-level-editor href="[[_getSelfLink(level)]]" token="[[token]]"></d2l-rubric-level-editor></div>
 		</template>
-		<div hidden="[[!hasOutOf]]" class="cell col-last"></div>
+		<div class="cell col-last">
+			<d2l-button-icon icon="d2l-tier2:add" text=[[localize('addLevel')]]></d2l-button-icon>
+		</div>
 	</template>
 
 	<script>
@@ -42,11 +75,13 @@
 
 			behaviors: [
 				D2L.PolymerBehaviors.Rubric.EntityBehavior,
-				window.D2L.Hypermedia.HMConstantsBehavior
+				window.D2L.Hypermedia.HMConstantsBehavior,
+				D2L.PolymerBehaviors.Rubric.LocalizeBehavior
 			],
 
 			observers: [
 				'_onEntityChanged(entity)',
+				'_onHasOutOfChanged(hasOutOf)',
 			],
 
 			_onEntityChanged: function(entity) {
@@ -55,7 +90,11 @@
 				}
 				this._levels = entity.getSubEntitiesByClass(this.HypermediaClasses.rubrics.level);
 			},
-
+			_onHasOutOfChanged: function(hasOutOf) {
+				if (!hasOutOf) {
+					this.$$('.col-last').classList.add('empty');
+				}
+			}
 		});
 	</script>
 </dom-module>

--- a/lang/ar.html
+++ b/lang/ar.html
@@ -13,6 +13,7 @@
 	D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangArBehavior = {
 		ar: {
 			'addCriterion': 'Add Criterion',
+			'addLevel': 'Add Level',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDescriptionAriaLabel': 'Criterion description for level {level} of {levelCount}',
 			'criterionFeedbackAriaLabel': 'Criterion feedback for level {level} of {levelCount}',
@@ -33,6 +34,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'removeCriterion': 'Remove Criterion',
+			'removeLevel': 'Remove Level',
 			'rubricLoadingErrorMessage': 'عذرًا، تعذّر علينا عرض آلية التقييم.',
 			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'يسرد هذا الجدول أسماء المعايير وأسماء مجموعات المعايير في العمود الأول. يسرد الصف الأول أسماء المستويات ويحتوي مجموع الدرجات إذا كانت آلية التقييم تستخدم طريقة رقمية لتسجيل النقاط.',

--- a/lang/de.html
+++ b/lang/de.html
@@ -13,6 +13,7 @@
 	D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangDeBehavior = {
 		de: {
 			'addCriterion': 'Add Criterion',
+			'addLevel': 'Add Level',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDescriptionAriaLabel': 'Criterion description for level {level} of {levelCount}',
 			'criterionFeedbackAriaLabel': 'Criterion feedback for level {level} of {levelCount}',
@@ -33,6 +34,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'removeCriterion': 'Remove Criterion',
+			'removeLevel': 'Remove Level',
 			'rubricLoadingErrorMessage': 'Das Bewertungsschema konnte leider nicht angezeigt werden.',
 			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'In der ersten Spalte dieser Tabelle wird der Name der Kriterien und Kriteriengruppen aufgeführt. Die erste Zeile enthält die Namen der Niveaus sowie Punktzahlen, sofern für das Bewertungsschema eine numerische Bewertungsmethode verwendet wird.',

--- a/lang/en.html
+++ b/lang/en.html
@@ -13,6 +13,7 @@
 	D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangEnBehavior = {
 		en: {
 			'addCriterion': 'Add Criterion',
+			'addLevel': 'Add Level',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDescriptionAriaLabel': 'Criterion description for level {level} of {levelCount}',
 			'criterionFeedbackAriaLabel': 'Criterion feedback for level {level} of {levelCount}',
@@ -33,6 +34,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'removeCriterion': 'Remove Criterion',
+			'removeLevel': 'Remove Level',
 			'rubricLoadingErrorMessage': 'Sorry, we were unable to display the rubric.',
 			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'This table lists criteria and criteria group name in the first column. The first row lists level names and includes scores if the rubric uses a numeric scoring method.',

--- a/lang/es.html
+++ b/lang/es.html
@@ -13,6 +13,7 @@
 	D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangEsBehavior = {
 		es: {
 			'addCriterion': 'Add Criterion',
+			'addLevel': 'Add Level',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDescriptionAriaLabel': 'Criterion description for level {level} of {levelCount}',
 			'criterionFeedbackAriaLabel': 'Criterion feedback for level {level} of {levelCount}',
@@ -33,6 +34,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'removeCriterion': 'Remove Criterion',
+			'removeLevel': 'Remove Level',
 			'rubricLoadingErrorMessage': 'Lo sentimos, no pudimos mostrar la rúbrica.',
 			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'Esta tabla muestra los nombres de los criterios y de los grupos de criterios en la primera columna. La primera fila muestra los nombres de los niveles e incluye las puntuaciones si la rúbrica usa un método de puntuación numérico.',

--- a/lang/fr.html
+++ b/lang/fr.html
@@ -13,6 +13,7 @@
 	D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangFrBehavior = {
 		fr: {
 			'addCriterion': 'Add Criterion',
+			'addLevel': 'Add Level',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDescriptionAriaLabel': 'Criterion description for level {level} of {levelCount}',
 			'criterionFeedbackAriaLabel': 'Criterion feedback for level {level} of {levelCount}',
@@ -33,6 +34,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'removeCriterion': 'Remove Criterion',
+			'removeLevel': 'Remove Level',
 			'rubricLoadingErrorMessage': 'Désolé, impossible d\'afficher la rubrique.',
 			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'Ce tableau comprend les critères et le nom du groupe de critères dans la première colonne. La première rangée contient les noms de niveau et comprend des pointages si la rubrique utilise une méthode de pointage numérique.',

--- a/lang/ja.html
+++ b/lang/ja.html
@@ -13,6 +13,7 @@
 	D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangJaBehavior = {
 		ja: {
 			'addCriterion': 'Add Criterion',
+			'addLevel': 'Add Level',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDescriptionAriaLabel': 'Criterion description for level {level} of {levelCount}',
 			'criterionFeedbackAriaLabel': 'Criterion feedback for level {level} of {levelCount}',
@@ -33,6 +34,7 @@
 			'percentage': '{number} ％',
 			'predefinedFeedback': 'Predefined Feedback',
 			'removeCriterion': 'Remove Criterion',
+			'removeLevel': 'Remove Level',
 			'rubricLoadingErrorMessage': '申し訳ありません。注釈を表示できませんでした。',
 			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'この表では 1 列目に条件と条件グループの名前が表示されます。注釈で数値によるスコアリング方法が使用されている場合、1 列目にはレベルが表示され、スコアが記載されます。',

--- a/lang/ko.html
+++ b/lang/ko.html
@@ -13,6 +13,7 @@
 	D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangKoBehavior = {
 		ko: {
 			'addCriterion': 'Add Criterion',
+			'addLevel': 'Add Level',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDescriptionAriaLabel': 'Criterion description for level {level} of {levelCount}',
 			'criterionFeedbackAriaLabel': 'Criterion feedback for level {level} of {levelCount}',
@@ -33,6 +34,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'removeCriterion': 'Remove Criterion',
+			'removeLevel': 'Remove Level',
 			'rubricLoadingErrorMessage': '죄송합니다, 루브릭을 표시할 수 없습니다.',
 			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': '이 표에는 첫 번째 열에 기준 및 기준 그룹 이름이 나열됩니다. 루브릭이 숫자 점수 산정법을 사용할 경우, 첫 번째 행에 수준 이름이 나열되고 점수가 포함됩니다.',

--- a/lang/nl.html
+++ b/lang/nl.html
@@ -13,6 +13,7 @@
 	D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangNlBehavior = {
 		nl: {
 			'addCriterion': 'Add Criterion',
+			'addLevel': 'Add Level',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDescriptionAriaLabel': 'Criterion description for level {level} of {levelCount}',
 			'criterionFeedbackAriaLabel': 'Criterion feedback for level {level} of {levelCount}',
@@ -33,6 +34,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'removeCriterion': 'Remove Criterion',
+			'removeLevel': 'Remove Level',
 			'rubricLoadingErrorMessage': 'We kunnen de rubric niet weergeven.',
 			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'In de eerste kolom van deze tabel staan de criteria en de criteriagroepnaam. In de eerste rij staan de niveaunamen en eventueel de scores als de rubric gebruikmaakt van een numerieke scoremethode.',

--- a/lang/pt.html
+++ b/lang/pt.html
@@ -13,6 +13,7 @@
 	D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangPtBehavior = {
 		pt: {
 			'addCriterion': 'Add Criterion',
+			'addLevel': 'Add Level',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDescriptionAriaLabel': 'Criterion description for level {level} of {levelCount}',
 			'criterionFeedbackAriaLabel': 'Criterion feedback for level {level} of {levelCount}',
@@ -33,6 +34,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'removeCriterion': 'Remove Criterion',
+			'removeLevel': 'Remove Level',
 			'rubricLoadingErrorMessage': 'Infelizmente, não foi possível exibir a rubrica.',
 			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'A tabela lista critérios e nomes de grupos de critérios na primeira coluna. A primeira linha lista nomes de nível e inclui pontuações caso a rubrica use um método de pontuação numérica.',

--- a/lang/sv.html
+++ b/lang/sv.html
@@ -13,6 +13,7 @@
 	D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangSvBehavior = {
 		sv: {
 			'addCriterion': 'Add Criterion',
+			'addLevel': 'Add Level',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDescriptionAriaLabel': 'Criterion description for level {level} of {levelCount}',
 			'criterionFeedbackAriaLabel': 'Criterion feedback for level {level} of {levelCount}',
@@ -33,6 +34,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'removeCriterion': 'Remove Criterion',
+			'removeLevel': 'Remove Level',
 			'rubricLoadingErrorMessage': 'Tyvärr, vi kunde inte visa rubricering.',
 			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'Denna tabell innehåller kriterier och namn på kriteriegrupp i den första kolumnen. På den första raden listas nivånamn och betyg inkluderas om rubriceringen använder en numerisk betygsättningsmetod.',

--- a/lang/tr.html
+++ b/lang/tr.html
@@ -13,6 +13,7 @@
 	D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangTrBehavior = {
 		tr: {
 			'addCriterion': 'Add Criterion',
+			'addLevel': 'Add Level',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDescriptionAriaLabel': 'Criterion description for level {level} of {levelCount}',
 			'criterionFeedbackAriaLabel': 'Criterion feedback for level {level} of {levelCount}',
@@ -33,6 +34,7 @@
 			'percentage': '%{number}',
 			'predefinedFeedback': 'Predefined Feedback',
 			'removeCriterion': 'Remove Criterion',
+			'removeLevel': 'Remove Level',
 			'rubricLoadingErrorMessage': 'Üzgünüz; rubrik görüntülenemedi.',
 			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': 'Bu tablo, ilk sütundaki kriter ve kriter grubu adlarını listeler. İlk satır seviye adlarını listeler ve rubrik sayısal bir puanlama yöntemi kullanıyorsa puanları içerir.',

--- a/lang/zh-tw.html
+++ b/lang/zh-tw.html
@@ -13,6 +13,7 @@
 	D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangZhTwBehavior = {
 		zhTw: {
 			'addCriterion': 'Add Criterion',
+			'addLevel': 'Add Level',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDescriptionAriaLabel': 'Criterion description for level {level} of {levelCount}',
 			'criterionFeedbackAriaLabel': 'Criterion feedback for level {level} of {levelCount}',
@@ -33,6 +34,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'removeCriterion': 'Remove Criterion',
+			'removeLevel': 'Remove Level',
 			'rubricLoadingErrorMessage': '抱歉，我們無法顯示量規。',
 			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': '此表格會在第一欄列出標準和標準群組名稱。第一列會列出層級名稱並包含分數 (如果量規使用數字評分方法)。',

--- a/lang/zh.html
+++ b/lang/zh.html
@@ -13,6 +13,7 @@
 	D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangZhBehavior = {
 		zh: {
 			'addCriterion': 'Add Criterion',
+			'addLevel': 'Add Level',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDescriptionAriaLabel': 'Criterion description for level {level} of {levelCount}',
 			'criterionFeedbackAriaLabel': 'Criterion feedback for level {level} of {levelCount}',
@@ -33,6 +34,7 @@
 			'percentage': '{number} %',
 			'predefinedFeedback': 'Predefined Feedback',
 			'removeCriterion': 'Remove Criterion',
+			'removeLevel': 'Remove Level',
 			'rubricLoadingErrorMessage': '抱歉，我们无法显示量规。',
 			'rubricSavingErrorMessage': 'Something went wrong. Please check your rubric.',
 			'rubricSummaryA11y': '此表第一列中列出了标准和标准组名。第一行列出了级别名称；如果量规使用数字评分方法，则还包括分数。',


### PR DESCRIPTION
Added level buttons on either end. 
Added disabled trashcan buttons for each level so that we can see what it looks like with tall level headings.
Removed large tooltips for d2l-button-icon types since they already have browser tooltips built-in (as requested by design team).