### PR TITLE
Show trash can based on presence of criterion delete action

### DIFF
--- a/editor/d2l-rubric-criteria-editor.html
+++ b/editor/d2l-rubric-criteria-editor.html
@@ -44,7 +44,6 @@
 					token="[[token]]"
 					has-out-of="[[hasOutOf]]"
 					display-name-placeholder="[[_isFirst(index)]]"
-					more-than-one-criterion="[[_moreThanOne(criterionCount)]]"
 				>
 				</d2l-rubric-criterion-editor>
 			</fieldset>
@@ -131,10 +130,6 @@
 						this.fire('d2l-rubric-criterion-added');
 					}.bind(this));
 				}
-			},
-
-			_moreThanOne: function(number) {
-				return number > 1;
 			}
 
 		});

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -176,7 +176,7 @@
 		<div class="criterion-remove">
 			<d2l-button-icon
 				id="remove"
-				hidden$="[[!_showRemove(entity, moreThanOneCriterion)]]"
+				hidden$="[[!_canDelete]]"
 				icon="d2l-tier1:delete"
 				text="[[localize('removeCriterion')]]"
 				on-tap="_handleDeleteCriterion"
@@ -192,6 +192,10 @@
 				_canEdit: {
 					type: Boolean,
 					computed: '_canEditCriterion(entity)',
+				},
+				_canDelete: {
+					type: Boolean,
+					computed: '_canDeleteCriterion(entity)',
 				},
 				_nameRequired: {
 					type: Boolean,
@@ -211,10 +215,6 @@
 					type: Boolean,
 				},
 				animating: {
-					type: Boolean,
-					value: false
-				},
-				moreThanOneCriterion: {
 					type: Boolean,
 					value: false
 				}
@@ -304,10 +304,6 @@
 					return localize('criterionPlaceholder');
 				}
 				return '';
-			},
-
-			_showRemove: function(entity, moreThanOneCriterion) {
-				return this._canDeleteCriterion(entity) && moreThanOneCriterion;
 			},
 
 			_handleDeleteCriterion: function() {

--- a/test/components/d2l-rubric-criterion-editor.html
+++ b/test/components/d2l-rubric-criterion-editor.html
@@ -34,15 +34,6 @@
 				</d2l-rubric-criterion-editor>
 			</template>
 		</test-fixture>
-		<test-fixture id="moreThanOneCriterion">
-			<template>
-				<d2l-rubric-criterion-editor
-					href="static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
-					more-than-one-criterion="true"
-				>
-				</d2l-rubric-criterion-editor>
-			</template>
-		</test-fixture>
 		<script src="d2l-rubric-criterion-editor.js"></script>
 
 		<script>

--- a/test/components/d2l-rubric-criterion-editor.js
+++ b/test/components/d2l-rubric-criterion-editor.js
@@ -106,11 +106,6 @@ suite('<d2l-rubric-criterion-editor>', function() {
 					nameTextArea.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: false, composed: true }));
 				});
 			});
-
-			test('remove is hidden (as moreThanOneCriterion is false)', function() {
-				var removeButton = element.$.remove;
-				expect(isVisible(removeButton)).to.be.false;
-			});
 		});
 
 		suite('readonly', function() {
@@ -140,35 +135,13 @@ suite('<d2l-rubric-criterion-editor>', function() {
 			});
 		});
 
-		suite('moreThanOneCriterion', function() {
-
-			var element;
-
-			setup(function(done) {
-				element = fixture('moreThanOneCriterion');
-				function waitForLoad(e) {
-					if (e.detail.entity.getLinkByRel('self').href === 'static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json') {
-						element.removeEventListener('d2l-rubric-entity-changed', waitForLoad);
-						done();
-					}
-				}
-				element.addEventListener('d2l-rubric-entity-changed', waitForLoad);
-				element.token = 'foozleberries';
-			});
-
-			test('remove is visible', function() {
-				var removeButton = element.$.remove;
-				expect(isVisible(removeButton)).to.be.true;
-			});
-		});
-
-		suite('remove criterion', function() {
+		suite('delete criterion', function() {
 
 			var fetch;
 			var element;
 
 			setup(function(done) {
-				element = fixture('moreThanOneCriterion');
+				element = fixture('basic');
 				function waitForLoad(e) {
 					if (e.detail.entity.getLinkByRel('self').href === 'static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json') {
 						element.removeEventListener('d2l-rubric-entity-changed', waitForLoad);
@@ -182,6 +155,11 @@ suite('<d2l-rubric-criterion-editor>', function() {
 			teardown(function() {
 				fetch && fetch.restore();
 				window.D2L.Rubric.EntityStore.clear();
+			});
+
+			test('remove is visible', function() {
+				var removeButton = element.$.remove;
+				expect(isVisible(removeButton)).to.be.true;
 			});
 
 			test('generates event if deleting fails', function(done) {


### PR DESCRIPTION
Instead of counting number of criterion in the criteria collection and showing the trash can based on that, we should show the trash can if the criterion has the delete action.

(After deleting, if there is only 1 criterion remaining, the API will include a link header to the last criterion. We fetch this last criterion and it will return without the delete action)