### PR TITLE
add link header processing to refresh dependent components that chang…

### DIFF
--- a/store/entity-store.html
+++ b/store/entity-store.html
@@ -59,7 +59,6 @@
 
 				// var headers = new Headers();
 				// headers.set('Authorization', `Bearer ${token}`);
-
 				// if (bypassCache) {
 				// 	headers.set('pragma', 'no-cache');
 				// 	headers.set('cache-control', 'no-cache');
@@ -84,8 +83,70 @@
 					this.setError(entityId, token, err);
 				}.bind(this));
 			}
-
 			return this._store.get(lowerCaseToken).get(lowerCaseEntityId);
+		},
+
+		// This newer version of fetch uses d2l-fetch directly so we can set
+		// appropriate headers to bypass caching done by the d2l-fetch middleware chain
+		// The intention is to replace the fetch implementation that uses d2l-fetch-siren-entity-behavior with this
+		// newer implementation.
+		//
+		// It is also now returning a promise so that the siren-action-behavior can co-ordinate
+		// updating the UI more consistently when dependent entities change as a result of Siren
+		// actions.
+		fetch2: function(entityId, token, bypassCache) {
+			const lowerCaseToken = token.toLowerCase();
+			const lowerCaseEntityId = entityId.toLowerCase();
+
+			var entity = this._initContainer(this._store, entityId, token);
+			if (!entity || bypassCache) {
+
+				var headers = new Headers();
+				headers.set('Authorization', `Bearer ${token}`);
+
+				if (bypassCache) {
+					headers.set('pragma', 'no-cache');
+					headers.set('cache-control', 'no-cache');
+				}
+
+				var request = window.d2lfetch.fetch(entityId, {
+					headers: headers
+				});
+				this._store.get(lowerCaseToken).set(lowerCaseEntityId, {
+					status: 'fetching',
+					entity: null,
+					request: request
+				});
+				return request.then(function(response) {
+					if (response.ok) {
+						return response.json();
+					}
+					return Promise.reject(response.status);
+				})
+				.then(function(body) {
+					var entity = window.D2L.Hypermedia.Siren.Parse(body);
+					this.update(entityId, token, entity);
+					if (bypassCache) {
+						this._invalidationListeners.forEach(function(listener) {
+							listener(entityId, token, entity);
+						});
+					}
+					return this._store.get(lowerCaseToken).get(lowerCaseEntityId);
+				}.bind(this))
+				.catch(function(err) {
+					this.setError(entityId, token, err);
+					return this._store.get(lowerCaseToken).get(lowerCaseEntityId);
+				}.bind(this));
+			}
+
+			if (entity.request) {
+				return request;
+			} else {
+				return new Promise(function(resolve) {
+					this._notify(lowerCaseEntityId, lowerCaseToken, entity.entity);
+					resolve(entity);
+				}.bind(this));
+			}
 		},
 
 		update: function(entityId, token, entity) {
@@ -96,7 +157,11 @@
 			return new Promise(function(resolve) {
 				const entities = this.expand(entity);
 				entities.forEach(function(entity) {
-					this._store.get(lowerCaseToken).set(entity.key.toLowerCase(), { 'status': '', 'entity': entity.value });
+					this._store.get(lowerCaseToken).set(entity.key.toLowerCase(), {
+						status: '',
+						entity: entity.value,
+						request: null
+					});
 					this._notify(entity.key, token, entity.value);
 				}.bind(this));
 
@@ -137,7 +202,12 @@
 			this._initContainer(this._store, entityId, token);
 			return new Promise(function(resolve) {
 
-				this._store.get(lowerCaseToken).set(lowerCaseEntityId, { 'status': 'error', 'entity': null, 'error': error });
+				this._store.get(lowerCaseToken).set(lowerCaseEntityId, {
+					status: 'error',
+					entity: null,
+					error: error,
+					request: null
+				});
 				this._notifyError(entityId, token, error);
 
 				resolve(error);
@@ -173,6 +243,43 @@
 			this._store = new Map();
 			this._listeners = new Map();
 			this._invalidationListeners = new Set();
+		},
+
+		// parse a Link header
+		//
+		// Link:<https://example.org/.meta>; rel=meta
+		//
+		// var r = parseLinkHeader(xhr.getResponseHeader('Link');
+		// r['meta'] outputs https://example.org/.meta
+		//
+		parseLinkHeader: function(links) {
+		    var linkexp = /<[^>]*>\s*(\s*;\s*[^\(\)<>@,;:"\/\[\]\?={} \t]+=(([^\(\)<>@,;:"\/\[\]\?={} \t]+)|("[^"]*")))*(,|$)/g;
+		    var paramexp = /[^\(\)<>@,;:"\/\[\]\?={} \t]+=(([^\(\)<>@,;:"\/\[\]\?={} \t]+)|("[^"]*"))/g;
+
+		    var matches = links.match(linkexp);
+		    var links = [];
+		    for (var i = 0; i < matches.length; i++) {
+		        var split = matches[i].split('>');
+		        var href = split[0].substring(1);
+				links.push({
+					href: href
+				})
+		        var ps = split[1];
+		        var s = ps.match(paramexp);
+		        for (var j = 0; j < s.length; j++) {
+		            var p = s[j];
+		            var paramsplit = p.split('=');
+		            var name = paramsplit[0];
+		            var val = paramsplit[1].replace(/["']/g, '');
+					if (name === 'rel') {
+						var relsplit = val.split(' ');
+						links[i][name] = relsplit;
+					} else {
+						links[i][name] = val;
+					}
+		        }
+		    }
+		    return links;
 		}
 	};
 })();

--- a/store/siren-action-behavior.html
+++ b/store/siren-action-behavior.html
@@ -82,7 +82,23 @@
 						self.fire('d2l-rubric-entity-save-error', { error: error });
 						throw error;
 					}
-					return resp.json();
+					var linkHeader = resp.headers ? resp.headers.get('Link') : null;
+					var links;
+					if (linkHeader) {
+						links = window.D2L.Rubric.EntityStore.parseLinkHeader(linkHeader);
+					}
+					if (resp.status === 204) {
+						return {
+							body: null,
+							links: links
+						};
+					}
+					return resp.json().then(function(body) {
+						return {
+							body: body,
+							links: links
+						}
+					});
 				});
 		},
 
@@ -121,9 +137,17 @@
 				body: body,
 				headers: headers
 			})
-				.then(function(body) {
-					var entity = window.D2L.Hypermedia.Siren.Parse(body);
-					return window.D2L.Rubric.EntityStore.update(url.href, token, entity);
+				.then(function(result) {
+					var linkRequests = [];
+					if (result.links) {
+						result.links.forEach(function(link) {
+							linkRequests.push(window.D2L.Rubric.EntityStore.fetch2(link.href, token, true));
+						});
+					}
+					var entity = window.D2L.Hypermedia.Siren.Parse(result.body);
+					return Promise.all(linkRequests).then(function() {
+						return window.D2L.Rubric.EntityStore.update(url.href, token, entity);
+					});
 				});
 		}
 	};

--- a/test/components/d2l-rubric-criteria-editor.js
+++ b/test/components/d2l-rubric-criteria-editor.js
@@ -44,7 +44,7 @@ suite('<d2l-rubric-criteria-editor>', function() {
 				window.D2L.Rubric.EntityStore.clear();
 			});
 
-			test.only('adds criterion', function(done) {
+			test('adds criterion', function(done) {
 				fetch = sinon.stub(window.d2lfetch, 'fetch');
 				var promise = Promise.resolve({
 					ok: true,

--- a/test/components/d2l-rubric-criteria-editor.js
+++ b/test/components/d2l-rubric-criteria-editor.js
@@ -44,7 +44,7 @@ suite('<d2l-rubric-criteria-editor>', function() {
 				window.D2L.Rubric.EntityStore.clear();
 			});
 
-			test('adds criterion', function(done) {
+			test.only('adds criterion', function(done) {
 				fetch = sinon.stub(window.d2lfetch, 'fetch');
 				var promise = Promise.resolve({
 					ok: true,


### PR DESCRIPTION
…e as a sresult of actions.

I've duplicated entity-store fetch implementation, that doesn't use the d2l-fetch-siren-entity-behavior. I ran into problems with that code, because d2l-fetch has some default caching (it caches response for 2 minutes) unless you do something to override that, e.g. setting no cache headers on the request, but d2l-fetch-siren-entity-behavior didn't allow us to access the request object or change the promise chain. 

This was breaking the reloading of the criterion collection, because it was continuing to use the cached version after deleting a criterion.

I don't think d2l-fetch-siren-entity-behavior is actually adding any value for our usage anyway and the whitelisting thing is a pain.  I've going to verify with Adrian Logan if they are ok for us to switch the implementation of our entity store to just use d2l-fetch directly.

I added promises to the entity store fetch implementation so that when the siren-action-behavior is handling the link headers, it can load each linked resource, before processing the response from the action. I'm thinking this might give us a bit more flexibility for handling actions and the changes. e.g. might help with animating adding levels etc. 