### PR TITLE
hide level trashcan instead of disable

### DIFF
--- a/editor/d2l-rubric-level-editor.html
+++ b/editor/d2l-rubric-level-editor.html
@@ -48,7 +48,7 @@
 				icon="d2l-tier1:delete"
 				text="[[localize('removeLevel')]]"
 				on-tap="_handleDeleteLevel"
-				disabled="[[!_canDelete]]">
+				hidden="[[!_canDelete]]">
 			</d2l-button-icon>
 		</div>
 		<template is="dom-if" if="[[_nameInvalid]]">


### PR DESCRIPTION
Fixes https://trello.com/c/pChYgDBy/13-rubric-delete-level-last-level-delete-level-trash-can-should-be-hidden-not-disabled-and-the-level-row-height-decreased