### PR TITLE
Increase height of empty criterion description cell editor

### DIFF
--- a/editor/d2l-rubric-criterion-description-editor.html
+++ b/editor/d2l-rubric-criterion-description-editor.html
@@ -13,6 +13,7 @@
 			:host {
 				display: flex;
 				flex-grow: 1;
+				min-height: 4rem;
 
 				--d2l-textarea: {
 					display: block;


### PR DESCRIPTION
Tweak styling of the criterion description cell editor to have a min height twice that of the predefined feedback cell.
https://trello.com/c/yoAtPcBX/18-rubric-criterion-description-cell-height-should-should-be-double-compared-to-predefined-feedback