### PR TITLE
Update to dependency versions using the newest icons

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,16 +25,16 @@
     "demo"
   ],
   "dependencies": {
-    "d2l-alert": "^3.0.1",
+    "d2l-alert": "^3.1.0",
     "d2l-colors": "^3.1.2",
     "d2l-fetch": "Brightspace/d2l-fetch#^1.8.0",
     "d2l-fetch-siren-entity-behavior": "Brightspace/d2l-fetch-siren-entity-behavior#^5.0.2",
     "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^5.8.0",
-    "d2l-icons": "^4.10.0",
+    "d2l-icons": "^5.0.0",
     "d2l-loading-spinner": "^6.0.2",
     "d2l-localize-behavior": "^1.1.0",
     "d2l-offscreen": "^3.0.3",
-    "d2l-table": "BrightspaceUI/table#^1.5.1",
+    "d2l-table": "BrightspaceUI/table#^1.7.0",
     "d2l-typography": "^6.1.2",
     "iron-media-query": "^2.1.0",
     "iron-resizable-behavior": "^2.1.0",
@@ -43,9 +43,9 @@
     "d2l-textarea": "BrightspaceUI/textarea#^0.6.1",
     "d2l-text-input": "BrightspaceUI/text-input#^0.4.0",
     "d2l-tooltip": "BrightspaceUI/tooltip#^2.0.4",
-    "d2l-button": "BrightspaceUI/button#^4.3.0",
+    "d2l-button": "BrightspaceUI/button#^4.5.0",
     "d2l-fastdom-import": "Brightspace/fastdom-import#^1.0.2",
-    "d2l-save-status": "Brightspace/d2l-save-status#^0.3.0"
+    "d2l-save-status": "Brightspace/d2l-save-status#^0.5.0"
   },
   "devDependencies": {
     "fetch": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-rubric",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "Polymer-based web components for D2L Rubrics",
   "private": true,
   "directories": {


### PR DESCRIPTION
No uses of `<d2l-icon-button>`