### PR TITLE
Fix IE11 spacing

### DIFF
--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -65,6 +65,10 @@
 				flex-direction: column;
 			}
 
+			.cell {
+				padding: 0.5rem;
+			}
+
 			.criterion-detail {
 				display: flex;
 				flex-grow: 1;
@@ -106,7 +110,7 @@
 
 			.col-last-empty {
 				min-width: calc(1rem + 44px); /* button width = 44px including border */
-				flex: 0 0 0;
+				flex: 0 0 0%;
 			}
 
 			.criterion-remove {

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -65,10 +65,6 @@
 				flex-direction: column;
 			}
 
-			.cell {
-				padding: 0.5rem;
-			}
-
 			.criterion-detail {
 				display: flex;
 				flex-grow: 1;

--- a/editor/d2l-rubric-editor-cell-styles.html
+++ b/editor/d2l-rubric-editor-cell-styles.html
@@ -23,7 +23,8 @@
 		.col-first {
 			flex-shrink: 0;
 			flex-grow: 0;
-			flex-basis: 15%;
+			flex-basis: auto;
+			width: 15%;
 			min-width: 7rem;
 			padding: 0;
 			border-left: none;

--- a/editor/d2l-rubric-levels-editor.html
+++ b/editor/d2l-rubric-levels-editor.html
@@ -47,7 +47,7 @@
 			}
 			.col-last[noOutOf] {
 				min-width: calc(1rem + 44px); /* button width = 44px including border */
-				flex: 0 0 0;
+				flex: 0 0 0%;
 			}
 		</style>
 


### PR DESCRIPTION
Fixes https://trello.com/c/Yy5aMio0/5-rubric-ie11-funky-spacing
IE doesn't accept `flex` to be set to `0 0 0` without any units ("invalid rule"), so changing it to `0 0 0%` fixes the width of the empty last column. The extra padding fixes the width of the first column and is in line with how the header row is styled.
This has been tested on Chrome, Chrome mobile view, Firefox, Edge, and IE.