### PR TITLE
integrate with reorder action and sorted event from d2l-dnd-sortable

### DIFF
--- a/editor/d2l-rubric-criteria-editor.html
+++ b/editor/d2l-rubric-criteria-editor.html
@@ -98,6 +98,8 @@
 			mirror-class="dnd-mirror"
 			touch-mirror-class="dnd-touch-mirror"
 			handle=".dnd-drag-handle"
+			on-d2l-dnd-sorted="_handleReorder"
+			disabled="[[!_canReorder]]"
 		>
 
 		<!--
@@ -119,6 +121,7 @@
 							class="dnd-drag-handle"
 							slot="gutter-left"
 							icon="d2l-tier1:menu-hamburger"
+							hidden="[[!_canReorder]]"
 						></d2l-icon>
 					</d2l-rubric-criterion-editor>
 				</div>
@@ -156,6 +159,10 @@
 				_canCreate: {
 					type: Boolean,
 					computed: '_canCreateCriterion(entity)',
+				},
+				_canReorder: {
+					type: Boolean,
+					computed: '_canReorderCriterion(entity)',
 				},
 			},
 
@@ -211,8 +218,22 @@
 						}.bind(this), 2000);
 					}.bind(this));
 				}
-			}
+			},
 
+			_canReorderCriterion: function(entity) {
+				return entity && entity.hasActionByName('reorder');
+			},
+
+			_handleReorder: function(e) {
+				var action = this.entity.getActionByName('reorder');
+				if (action) {
+					var fields = new FormData();
+					fields.append('oldIndex', e.detail.oldIndex);
+					fields.append('newIndex', e.detail.newIndex);
+					this.performSirenAction(action, fields).then(function() {
+					}.bind(this));
+				}
+			}
 		});
 	</script>
 </dom-module>

--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -70,6 +70,7 @@
 			is: 'd2l-rubric-criteria-group-editor',
 
 			properties: {
+				showGroupName: Boolean,
 				_levelsHref: String,
 				_criteriaCollectionHref: String,
 				_showContent: {
@@ -78,7 +79,7 @@
 				},
 				_nameInvalid: {
 					type: Boolean
-			},
+				},
 				_nameInvalidError: {
 					type: String
 				}

--- a/editor/d2l-rubric-editor-menu.html
+++ b/editor/d2l-rubric-editor-menu.html
@@ -3,7 +3,7 @@
 <link rel="import" href="../../d2l-icons/d2l-icon.html">
 <link rel="import" href="../../d2l-button/d2l-button-subtle.html">
 
-<dom-module id="d2l-rubrics-editor-menu">
+<dom-module id="d2l-rubric-editor-menu">
 	<template strip-whitespace>
 		<style>
 			:host {
@@ -32,7 +32,7 @@
 	</template>
 	<script>
 		Polymer({
-			is: 'd2l-rubrics-editor-menu',
+			is: 'd2l-rubric-editor-menu',
 
 			properties: {
 				reverseLevelsEnabled: {

--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -120,9 +120,9 @@ Creates and edits a rubric
 		<div hidden$="[[_hideLoading(_showContent,_hasAlerts)]]" class="out-of-loader">
 		</div>
 		<div hidden$="[[_hideOutOf(_showContent,_hasAlerts)]]">
-			<d2l-rubrics-editor-menu
+			<d2l-rubric-editor-menu
 				on-d2l-rubric-reverse-levels="_handleReverseLevels"
-				reverse-levels-enabled="[[_present(_reverseLevels)]]"></d2l-rubrics-editor-menu>
+				reverse-levels-enabled="[[_present(_reverseLevels)]]"></d2l-rubric-editor-menu>
 
 			<d2l-rubric-criteria-groups-editor href="[[_getHref(_criteriaGroups)]]" token="[[token]]"></d2l-rubric-criteria-groups-editor>
 			<div class="out-of-container" hidden="[[!_hasOutOf(entity)]]">

--- a/test/components/d2l-rubric-criteria-editor.js
+++ b/test/components/d2l-rubric-criteria-editor.js
@@ -1,4 +1,4 @@
-/* global suite, test, fixture, expect, setup, teardown, suiteSetup, suiteTeardown, sinon, stubWhitelist */
+/* global suite, test, fixture, expect, setup, teardown, suiteSetup, suiteTeardown, flush, sinon, stubWhitelist */
 
 'use strict';
 
@@ -79,6 +79,37 @@ suite('<d2l-rubric-criteria-editor>', function() {
 			});
 		});
 
+		suite('reorder criterion', function() {
+
+			var fetch;
+			var element;
+
+			setup(function(done) {
+				element = fixture('basic');
+				function waitForLoad(e) {
+					if (e.detail.entity.getLinkByRel('self').href === 'static-data/rubrics/organizations/text-only/199/groups/176/criteria.json') {
+						element.removeEventListener('d2l-rubric-entity-changed', waitForLoad);
+						done();
+					}
+				}
+				element.addEventListener('d2l-rubric-entity-changed', waitForLoad);
+				element.token = 'foozleberries';
+			});
+
+			teardown(function() {
+				fetch && fetch.restore();
+				window.D2L.Rubric.EntityStore.clear();
+			});
+
+			test('enables drag and drop', function(done) {
+				flush(function() {
+					var dragHandle = element.$$('.dnd-drag-handle');
+					expect(dragHandle.slot).to.equal('gutter-left');
+					done();
+				})
+			});
+		});
+
 		suite('readonly', function() {
 
 			var element;
@@ -98,6 +129,11 @@ suite('<d2l-rubric-criteria-editor>', function() {
 			test('add is disabled', function() {
 				var addButton = element.$$('d2l-button-subtle');
 				expect(addButton.disabled).to.be.true;
+			});
+
+			test('drag drop is disabled', function() {
+				var dragHandle = element.$$('.d2l-drag-handle');
+				expect(dragHandle).to.be.null;
 			});
 		});
 	});

--- a/test/components/d2l-rubric-criteria-editor.js
+++ b/test/components/d2l-rubric-criteria-editor.js
@@ -104,9 +104,9 @@ suite('<d2l-rubric-criteria-editor>', function() {
 			test('enables drag and drop', function(done) {
 				flush(function() {
 					var dragHandle = element.$$('.dnd-drag-handle');
-					expect(dragHandle.slot).to.equal('gutter-left');
+					expect(dragHandle.icon).to.equal('d2l-tier1:menu-hamburger');
 					done();
-				})
+				});
 			});
 		});
 

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria.json
@@ -8,6 +8,18 @@
       "method": "POST",
       "href":  "static-data/rubrics/organizations/text-only/199/groups/176/criteria.json",
       "fields": []
+    }, {
+      "name": "reorder",
+      "method": "POST",
+      "href":  "static-data/rubrics/organizations/text-only/199/groups/176/criteria-reorder",
+      "fields": [{
+          "name": "newIndex",
+          "type": "number"
+        }, {
+            "name": "oldIndex",
+            "type": "number"
+          }
+        ]
     }],
     "entities": [
         {


### PR DESCRIPTION
Uses the presence of a new `reorder` criteria action to determine whether drag drop should be enabled and whether the drag handles should be displayed.

Also hooks into the `d2l-dnd-sorted` event from `d2l-dnd-sortable` to determine when the action should be called.

I was running into some polymer lint issues with the latest master relating to the `showGroupName` property and the new `d2l-rubric-editor-menu`. Confused why they were not causing errors in the travis build, but I fixed them anyway.