### PR TITLE
Focus on new group name text box after adding new group

### DIFF
--- a/editor/d2l-rubric-criteria-groups-editor.html
+++ b/editor/d2l-rubric-criteria-groups-editor.html
@@ -89,6 +89,10 @@
 				if (action) {
 					this.performSirenAction(action).then(function() {
 						this.fire('d2l-rubric-criteria-group-added');
+					}.bind(this)).then(function() {
+						var allGroups = Polymer.dom(this.root).querySelectorAll('d2l-rubric-criteria-group-editor');
+						var lastGroup = allGroups[allGroups.length - 1];
+						lastGroup.$$('d2l-text-input').$$('input').select();
 					}.bind(this));
 				}
 			},


### PR DESCRIPTION
Addresses https://trello.com/c/lyIL54fx/24-criteria-group-when-adding-a-new-criteria-group-focus-should-be-placed-on-the-criteria-name-cell-currently-it-stays-on-the-add-c