### PR TITLE
Modify add level button to say 'before' or 'after' and with level name

### DIFF
--- a/editor/d2l-rubric-levels-editor.html
+++ b/editor/d2l-rubric-levels-editor.html
@@ -67,8 +67,9 @@
 			<slot name="group-name-slot"></slot>
 			<d2l-button-icon
 				on-tap="_handlePrependLevel"
+				on-focus="_onPrependFocus"
 				icon="d2l-tier2:add"
-				text=[[localize('addLevel')]]
+				text="[[localize('addLevelPrepend', 'name', '')]]"
 				disabled="[[!_canPrepend]]">
 			</d2l-button-icon>
 		</div>
@@ -78,8 +79,9 @@
 		<div class="cell col-last" noOutOf$=[[!hasOutOf]]>
 			<d2l-button-icon
 				on-tap="_handleAppendLevel"
+				on-focus="_onAppendFocus"
 				icon="d2l-tier2:add"
-				text=[[localize('addLevel')]]
+				text="[[localize('addLevelAppend', 'name', '')]]"
 				disabled="[[!_canAppend]]">
 			</d2l-button-icon>
 		</div>
@@ -132,25 +134,37 @@
 			_handlePrependLevel: function() {
 				var action = this.entity.getActionByName('prepend');
 				if (action) {
-					var firstLevel = this.$$('d2l-rubric-level-editor');
-					var levelName = firstLevel ? firstLevel.entity.properties.name : '';
+					var firstLevelName = this._getFirstLevelName();
 					this.performSirenAction(action).then(function() {
 						this.fire('d2l-rubric-level-added');
-						this.fire('iron-announce', { text: this.localize('levelPrepended', 'name', levelName) }, { bubbles: true });
+						this.fire('iron-announce', { text: this.localize('levelPrepended', 'name', firstLevelName) }, { bubbles: true });
 					}.bind(this));
 				}
 			},
 			_handleAppendLevel: function() {
 				var action = this.entity.getActionByName('append');
 				if (action) {
-					var levels = Polymer.dom(this.root).querySelectorAll('d2l-rubric-level-editor');
-					var levelName = levels.length ? levels[levels.length - 1].entity.properties.name : '';
+					var lastLevelName = this._getLastLevelName();
 					this.performSirenAction(action).then(function() {
 						this.fire('d2l-rubric-level-added');
-						this.fire('iron-announce', { text: this.localize('levelAppended', 'name', levelName) }, { bubbles: true });
+						this.fire('iron-announce', { text: this.localize('levelAppended', 'name', lastLevelName) }, { bubbles: true });
 					}.bind(this));
 				}
 			},
+			_getFirstLevelName: function() {
+				var firstLevel = this.$$('d2l-rubric-level-editor');
+				return firstLevel ? firstLevel.entity.properties.name : '';
+			},
+			_getLastLevelName: function() {
+				var levels = Polymer.dom(this.root).querySelectorAll('d2l-rubric-level-editor');
+				return levels.length ? levels[levels.length - 1].entity.properties.name : '';
+			},
+			_onPrependFocus: function() {
+				this.fire('iron-announce', { text: this.localize('addLevelPrepend', 'name', this._getFirstLevelName()) }, { bubbles: true });
+			},
+			_onAppendFocus: function() {
+				this.fire('iron-announce', { text: this.localize('addLevelAppend', 'name', this._getLastLevelName()) }, { bubbles: true });
+			}
 		});
 	</script>
 </dom-module>

--- a/lang/ar.html
+++ b/lang/ar.html
@@ -14,7 +14,8 @@
 		ar: {
 			'addCriteriaGroup': 'Add Criteria Group',
 			'addCriterion': 'Add Criterion',
-			'addLevel': 'Add Level',
+			'addLevelPrepend': 'Add new level before {name}',
+			'addLevelAppend': 'Add new level after {name}',
 			'criterionAdded': 'A new criterion has been added',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDeleted': '{name} criterion deleted',

--- a/lang/de.html
+++ b/lang/de.html
@@ -14,7 +14,8 @@
 		de: {
 			'addCriteriaGroup': 'Add Criteria Group',
 			'addCriterion': 'Add Criterion',
-			'addLevel': 'Add Level',
+			'addLevelPrepend': 'Add new level before {name}',
+			'addLevelAppend': 'Add new level after {name}',
 			'criterionAdded': 'A new criterion has been added',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDeleted': '{name} criterion deleted',

--- a/lang/en.html
+++ b/lang/en.html
@@ -14,7 +14,8 @@
 		en: {
 			'addCriteriaGroup': 'Add Criteria Group',
 			'addCriterion': 'Add Criterion',
-			'addLevel': 'Add Level',
+			'addLevelPrepend': 'Add new level before {name}',
+			'addLevelAppend': 'Add new level after {name}',
 			'criterionAdded': 'A new criterion has been added',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDeleted': '{name} criterion deleted',

--- a/lang/es.html
+++ b/lang/es.html
@@ -14,7 +14,8 @@
 		es: {
 			'addCriteriaGroup': 'Add Criteria Group',
 			'addCriterion': 'Add Criterion',
-			'addLevel': 'Add Level',
+			'addLevelPrepend': 'Add new level before {name}',
+			'addLevelAppend': 'Add new level after {name}',
 			'criterionAdded': 'A new criterion has been added',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDeleted': '{name} criterion deleted',

--- a/lang/fr.html
+++ b/lang/fr.html
@@ -14,7 +14,8 @@
 		fr: {
 			'addCriteriaGroup': 'Add Criteria Group',
 			'addCriterion': 'Add Criterion',
-			'addLevel': 'Add Level',
+			'addLevelPrepend': 'Add new level before {name}',
+			'addLevelAppend': 'Add new level after {name}',
 			'criterionAdded': 'A new criterion has been added',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDeleted': '{name} criterion deleted',

--- a/lang/ja.html
+++ b/lang/ja.html
@@ -14,7 +14,8 @@
 		ja: {
 			'addCriteriaGroup': 'Add Criteria Group',
 			'addCriterion': 'Add Criterion',
-			'addLevel': 'Add Level',
+			'addLevelPrepend': 'Add new level before {name}',
+			'addLevelAppend': 'Add new level after {name}',
 			'criterionAdded': 'A new criterion has been added',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDeleted': '{name} criterion deleted',

--- a/lang/ko.html
+++ b/lang/ko.html
@@ -14,7 +14,8 @@
 		ko: {
 			'addCriteriaGroup': 'Add Criteria Group',
 			'addCriterion': 'Add Criterion',
-			'addLevel': 'Add Level',
+			'addLevelPrepend': 'Add new level before {name}',
+			'addLevelAppend': 'Add new level after {name}',
 			'criterionAdded': 'A new criterion has been added',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDeleted': '{name} criterion deleted',

--- a/lang/nl.html
+++ b/lang/nl.html
@@ -14,7 +14,8 @@
 		nl: {
 			'addCriteriaGroup': 'Add Criteria Group',
 			'addCriterion': 'Add Criterion',
-			'addLevel': 'Add Level',
+			'addLevelPrepend': 'Add new level before {name}',
+			'addLevelAppend': 'Add new level after {name}',
 			'criterionAdded': 'A new criterion has been added',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDeleted': '{name} criterion deleted',

--- a/lang/pt.html
+++ b/lang/pt.html
@@ -14,7 +14,8 @@
 		pt: {
 			'addCriteriaGroup': 'Add Criteria Group',
 			'addCriterion': 'Add Criterion',
-			'addLevel': 'Add Level',
+			'addLevelPrepend': 'Add new level before {name}',
+			'addLevelAppend': 'Add new level after {name}',
 			'criterionAdded': 'A new criterion has been added',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDeleted': '{name} criterion deleted',

--- a/lang/sv.html
+++ b/lang/sv.html
@@ -14,7 +14,8 @@
 		sv: {
 			'addCriteriaGroup': 'Add Criteria Group',
 			'addCriterion': 'Add Criterion',
-			'addLevel': 'Add Level',
+			'addLevelPrepend': 'Add new level before {name}',
+			'addLevelAppend': 'Add new level after {name}',
 			'criterionAdded': 'A new criterion has been added',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDeleted': '{name} criterion deleted',

--- a/lang/tr.html
+++ b/lang/tr.html
@@ -14,7 +14,8 @@
 		tr: {
 			'addCriteriaGroup': 'Add Criteria Group',
 			'addCriterion': 'Add Criterion',
-			'addLevel': 'Add Level',
+			'addLevelPrepend': 'Add new level before {name}',
+			'addLevelAppend': 'Add new level after {name}',
 			'criterionAdded': 'A new criterion has been added',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDeleted': '{name} criterion deleted',

--- a/lang/zh-tw.html
+++ b/lang/zh-tw.html
@@ -14,7 +14,8 @@
 		zhTw: {
 			'addCriteriaGroup': 'Add Criteria Group',
 			'addCriterion': 'Add Criterion',
-			'addLevel': 'Add Level',
+			'addLevelPrepend': 'Add new level before {name}',
+			'addLevelAppend': 'Add new level after {name}',
 			'criterionAdded': 'A new criterion has been added',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDeleted': '{name} criterion deleted',

--- a/lang/zh.html
+++ b/lang/zh.html
@@ -14,7 +14,8 @@
 		zh: {
 			'addCriteriaGroup': 'Add Criteria Group',
 			'addCriterion': 'Add Criterion',
-			'addLevel': 'Add Level',
+			'addLevelPrepend': 'Add new level before {name}',
+			'addLevelAppend': 'Add new level after {name}',
 			'criterionAdded': 'A new criterion has been added',
 			'criterionAriaLabel': 'Criterion {index, number} of {count, number}',
 			'criterionDeleted': '{name} criterion deleted',


### PR DESCRIPTION
**Currently, Level + buttons just say "Add level". Modify to say
"Add new level before {firstLevel.name}" or
"Add new level after {lastLevel.Name}"**


If we attempt to modify the existing `text` property on `d2l-button-icon` to include the level name, we have to dynamically update the value. We have to update the value in these scenarios: when a level name changes, after a new level is added, after a level is deleted, and maybe after reverse levels.

With level name changes, I can listen to the 'save' event. With the 'add' and 'delete' level stuff, I can't just observe the `_levels` property to get the name as they can be `linkedSubEntities`. So I'm relying on querying for all the `level` elements in the DOM. This means I can't just listen to the 'add' or 'delete' event, as it'll depend on the DOM to be finished updating. In the case of adding a level, I also have to wait for the API call to finish fetching the level. In the case of delete, the element needs to be detached from the DOM, but when that happens, it won't be able to notify the levels element, unless I fetch levels (/parent element) before the element is detached in order to call a function in levels after it's detached to notify that an element is detached. Anyways, it's a big headache and messy.

So I approached this by modifying the aria-label to say 'Add new level before' and 'Add new level after' without the level.  Then, have it announce another 'Add new level before/after {levelName}', this time with the level name using the iron-a11y-announce component. If we don't want to announce it twice, I could decide not to pass a `text` property, but we would lose the tooltip.