### PR TITLE
Fix IE11 group name focus issue

### DIFF
--- a/editor/d2l-rubric-criteria-groups-editor.html
+++ b/editor/d2l-rubric-criteria-groups-editor.html
@@ -112,7 +112,7 @@
 						setTimeout(function() {
 							this.fire('iron-announce', { text: this.localize('groupAdded') }, { bubbles: true });
 						}.bind(this), 2000);
-					}.bind(this), function() {
+					}.bind(this)).catch(function() {
 						this._waitingForGroups = false;
 					}.bind(this));
 				}

--- a/editor/d2l-rubric-criteria-groups-editor.html
+++ b/editor/d2l-rubric-criteria-groups-editor.html
@@ -107,11 +107,13 @@
 				var action = this.entity.getActionByName('create');
 				if (action) {
 					this._waitingForGroups = true;
-					this.performSirenAction(action).then(function() {
+					this.performSirenAction(action).then( function() {
 						this.fire('d2l-rubric-criteria-group-added');
 						setTimeout(function() {
 							this.fire('iron-announce', { text: this.localize('groupAdded') }, { bubbles: true });
 						}.bind(this), 2000);
+					}.bind(this), function() {
+						this._waitingForGroups = false;
 					}.bind(this));
 				}
 			},

--- a/editor/d2l-rubric-criteria-groups-editor.html
+++ b/editor/d2l-rubric-criteria-groups-editor.html
@@ -77,6 +77,11 @@
 				_canCreate: {
 					type: Boolean,
 					computed: '_canCreateCriteriaGroup(entity)'
+				},
+
+				_waitingForGroups: {
+					type: Boolean,
+					value: false
 				}
 			},
 
@@ -101,7 +106,7 @@
 			_handleAddCriteriaGroup: function() {
 				var action = this.entity.getActionByName('create');
 				if (action) {
-					this.addEventListener('d2l-rubric-group-complete', this._refocus);
+					this._waitingForGroups = true;
 					this.performSirenAction(action).then(function() {
 						this.fire('d2l-rubric-criteria-group-added');
 						setTimeout(function() {
@@ -117,13 +122,15 @@
 				return entity.entities.length > 1;
 			},
 			_groupsDomComplete: function() {
-				this.fire('d2l-rubric-group-complete');
+				if (this._waitingForGroups) {
+					this._waitingForGroups = false;
+					this._refocus();
+				}
 			},
-			_refocus: function(e) {
+			_refocus: function() {
 				allGroups = Polymer.dom(this.root).querySelectorAll('d2l-rubric-criteria-group-editor');
 				var lastGroup = allGroups[allGroups.length - 1];
 				lastGroup.$$('d2l-text-input').$$('input').select();
-				e.target.removeEventListener(e.type, arguments.callee);
 			}
 		});
 	</script>

--- a/editor/d2l-rubric-criteria-groups-editor.html
+++ b/editor/d2l-rubric-criteria-groups-editor.html
@@ -42,7 +42,7 @@
 
 		<d2l-rubric-loading hidden$="[[_showContent]]"></d2l-rubric-loading>
 
-		<template is="dom-repeat" items="[[_groups]]">
+		<template is="dom-repeat" items="[[_groups]]" on-dom-change="_groupsDomComplete">
 			<d2l-rubric-criteria-group-editor
 				hidden$="[[!_showContent]]"
 				href="[[_getSelfLink(item)]]"
@@ -101,23 +101,12 @@
 			_handleAddCriteriaGroup: function() {
 				var action = this.entity.getActionByName('create');
 				if (action) {
+					this.addEventListener('d2l-rubric-group-complete', this._refocus);
 					this.performSirenAction(action).then(function() {
 						this.fire('d2l-rubric-criteria-group-added');
 						setTimeout(function() {
 							this.fire('iron-announce', { text: this.localize('groupAdded') }, { bubbles: true });
 						}.bind(this), 2000);
-						var allGroups = Polymer.dom(this.root).querySelectorAll('d2l-rubric-criteria-group-editor');
-						// If the DOM takes too long to update (as in IE11), delay setting the focus
-						if (this.entity.entities.length !== allGroups.length) {
-							setTimeout(function() {
-								allGroups = Polymer.dom(this.root).querySelectorAll('d2l-rubric-criteria-group-editor');
-								var lastGroup = allGroups[allGroups.length - 1];
-								lastGroup.$$('d2l-text-input').$$('input').select();
-							}.bind(this), 50);
-						} else {
-							var lastGroup = allGroups[allGroups.length - 1];
-							lastGroup.$$('d2l-text-input').$$('input').select();
-						}
 					}.bind(this));
 				}
 			},
@@ -126,6 +115,15 @@
 			},
 			_showGroupName: function(entity) {
 				return entity.entities.length > 1;
+			},
+			_groupsDomComplete: function() {
+				this.fire('d2l-rubric-group-complete');
+			},
+			_refocus: function(e) {
+				allGroups = Polymer.dom(this.root).querySelectorAll('d2l-rubric-criteria-group-editor');
+				var lastGroup = allGroups[allGroups.length - 1];
+				lastGroup.$$('d2l-text-input').$$('input').select();
+				e.target.removeEventListener(e.type, arguments.callee);
 			}
 		});
 	</script>

--- a/editor/d2l-rubric-criteria-groups-editor.html
+++ b/editor/d2l-rubric-criteria-groups-editor.html
@@ -106,10 +106,18 @@
 						setTimeout(function() {
 							this.fire('iron-announce', { text: this.localize('groupAdded') }, { bubbles: true });
 						}.bind(this), 2000);
-					}.bind(this)).then(function() {
 						var allGroups = Polymer.dom(this.root).querySelectorAll('d2l-rubric-criteria-group-editor');
-						var lastGroup = allGroups[allGroups.length - 1];
-						lastGroup.$$('d2l-text-input').$$('input').select();
+						// If the DOM takes too long to update (as in IE11), delay setting the focus
+						if (this.entity.entities.length !== allGroups.length) {
+							setTimeout(function() {
+								allGroups = Polymer.dom(this.root).querySelectorAll('d2l-rubric-criteria-group-editor');
+								var lastGroup = allGroups[allGroups.length - 1];
+								lastGroup.$$('d2l-text-input').$$('input').select();
+							}.bind(this), 50);
+						} else {
+							var lastGroup = allGroups[allGroups.length - 1];
+							lastGroup.$$('d2l-text-input').$$('input').select();
+						}
 					}.bind(this));
 				}
 			},


### PR DESCRIPTION
Addresses https://trello.com/c/NcXxPkiH/29-ie11-when-adding-a-new-criterion-group-focus-goes-to-first-criterion-group-name-not-the-newly-added-one-as-intended

In cases where the DOM is slow to update, the new group is not yet present when trying to select it for setting the focus to its name. ~So in those cases, an explicit delay is added to give the DOM time to update so that the correct group will be selected.
(I'm not huge on the setTimeout approach, even if the delay is only 50 ms, so any suggestions for alternative approaches welcome!)~