### PR TITLE
Fix aria label update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,7 +46,6 @@
     "d2l-dnd-sortable": "Brightspace/dnd-sortable#^0.0.4",
     "iron-a11y-announcer": "^2.1.0",
     "d2l-telemetry-browser-client": "Brightspace/d2l-telemetry-browser-client#^0.4.0",
-    "iron-a11y-announcer": "^2.1.0",
     "iron-media-query": "^2.1.0",
     "iron-resizable-behavior": "^2.1.0",
     "polymer": "1 - 2",

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -149,7 +149,8 @@
 						<d2l-rubric-description-editor
 							href="[[_getSelfLink(criterionCell)]]"
 							token="[[token]]"
-							aria-label-text="[[_getAriaLabel('criterionDescriptionAriaLabel', entity.properties.name, criterionCell.properties.levelName)]]"
+							aria-label-langterm="criterionDescriptionAriaLabel"
+							criterion-name="[[entity.properties.name]]"
 							level-index="[[cellIndex]]"
 							level-count="[[descriptionCount]]"
 						></d2l-rubric-description-editor>
@@ -163,7 +164,8 @@
 						<d2l-rubric-feedback-editor
 							href="[[_getSelfLink(criterionCell)]]"
 							token="[[token]]"
-							aria-label-text="[[_getAriaLabel('criterionFeedbackAriaLabel', entity.properties.name, criterionCell.properties.levelName)]]"
+							aria-label-langterm="criterionFeedbackAriaLabel"
+							criterion-name="[[entity.properties.name]]"
 							level-index="[[cellIndex]]"
 							level-count="[[feedbackCount]]"
 						>
@@ -226,10 +228,6 @@
 				window.D2L.Hypermedia.HMConstantsBehavior,
 				D2L.PolymerBehaviors.Rubric.LocalizeBehavior
 			],
-
-			_getAriaLabel: function(langTerm, criterionName, levelName) {
-				return this.localize(langTerm, 'criterionName', criterionName, 'levelName', levelName);
-			},
 
 			_onEntityChanged: function(entity, oldEntity) {
 				if (!entity) {

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -144,30 +144,26 @@
 		</div>
 		<div class="criterion-detail">
 			<div class="criterion-text">
-				<template is="dom-repeat" as="criterionCell" items="[[_getCriterionCells(entity)]]" index-as="cellIndex" rendered-item-count="{{descriptionCount}}" >
+				<template is="dom-repeat" as="criterionCell" items="[[_getCriterionCells(entity)]]" >
 					<div class="cell">
 						<d2l-rubric-description-editor
 							href="[[_getSelfLink(criterionCell)]]"
 							token="[[token]]"
 							aria-label-langterm="criterionDescriptionAriaLabel"
 							criterion-name="[[entity.properties.name]]"
-							level-index="[[cellIndex]]"
-							level-count="[[descriptionCount]]"
 						></d2l-rubric-description-editor>
 					</div>
 				</template>
 			</div>
 			<div class="cell criterion-feedback-header">[[localize('predefinedFeedback')]]</div>
 			<div class="criterion-feedback">
-				<template is="dom-repeat" as="criterionCell" items="[[_getCriterionCells(entity)]]" index-as="cellIndex" rendered-item-count="{{feedbackCount}}" >
+				<template is="dom-repeat" as="criterionCell" items="[[_getCriterionCells(entity)]]">
 					<div class="cell">
 						<d2l-rubric-feedback-editor
 							href="[[_getSelfLink(criterionCell)]]"
 							token="[[token]]"
 							aria-label-langterm="criterionFeedbackAriaLabel"
 							criterion-name="[[entity.properties.name]]"
-							level-index="[[cellIndex]]"
-							level-count="[[feedbackCount]]"
 						>
 						</d2l-rubric-feedback-editor>
 					</div>

--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -66,19 +66,7 @@
 					type: String,
 					value: ''
 				},
-				/**
-				 * Index of this level in the collection - useful for aria labels
-				 */
-				levelIndex: String,
-				/**
-				 * Count of levels in the collection - useful for aria labels
-				 */
-				levelCount: Number,
 
-				_levelOffset: {
-					type: Number,
-					computed: '_calcOffset(levelIndex)',
-				},
 				_canEdit: {
 					type: Boolean,
 					computed: '_canEditDescription(entity)',
@@ -108,9 +96,6 @@
 				return description && description.properties && description.properties.html || '';
 			},
 
-			_calcOffset: function(index) {
-				return parseInt(index) + 1;
-			},
 			_saveDescription: function(e) {
 				var description = this.entity && this.entity.getSubEntityByClass(this.HypermediaClasses.rubrics.description);
 				var action = description.getActionByName('update');

--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -38,7 +38,7 @@
 		<d2l-textarea
 			id="description"
 			aria-invalid="[[_isAriaInvalid(_descriptionInvalid)]]"
-			aria-label="[[ariaLabelText]]"
+			aria-label="[[_getAriaLabel(ariaLabelLangterm, criterionName, entity.properties)]]"
 			disabled="[[!_canEdit]]"
 			no-border
 			hover-styles
@@ -58,7 +58,11 @@
 				/**
 				 * textarea aria-label langterm
 				 */
-				ariaLabelText: {
+				ariaLabelLangterm: {
+					type: String,
+					value: ''
+				},
+				criterionName: {
 					type: String,
 					value: ''
 				},
@@ -93,6 +97,11 @@
 				window.D2L.Hypermedia.HMConstantsBehavior,
 				D2L.PolymerBehaviors.Rubric.LocalizeBehavior
 			],
+
+			_getAriaLabel: function(langTerm, criterionName, properties) {
+				var levelName = properties.levelName || properties.name;
+				return this.localize(langTerm, 'criterionName', criterionName, 'levelName', levelName);
+			},
 
 			_getDescription: function(entity) {
 				var description = entity && entity.getSubEntityByClass(this.HypermediaClasses.rubrics.description);

--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -87,7 +87,7 @@
 			],
 
 			_getAriaLabel: function(langTerm, criterionName, properties) {
-				var levelName = properties.levelName || properties.name;
+				var levelName = properties && properties.levelName || properties && properties.name;
 				return this.localize(langTerm, 'criterionName', criterionName, 'levelName', levelName);
 			},
 

--- a/editor/d2l-rubric-feedback-editor.html
+++ b/editor/d2l-rubric-feedback-editor.html
@@ -86,7 +86,7 @@
 			],
 
 			_getAriaLabel: function(langTerm, criterionName, properties) {
-				var levelName = properties.levelName || properties.name;
+				var levelName = properties && properties.levelName || properties && properties.name;
 				return this.localize(langTerm, 'criterionName', criterionName, 'levelName', levelName);
 			},
 

--- a/editor/d2l-rubric-feedback-editor.html
+++ b/editor/d2l-rubric-feedback-editor.html
@@ -37,7 +37,7 @@
 		<d2l-textarea
 			id="feedback"
 			aria-invalid="[[_isAriaInvalid(_feedbackInvalid)]]"
-			aria-label="[[ariaLabelText]]"
+			aria-label="[[_getAriaLabel(ariaLabelLangterm, criterionName, entity.properties)]]"
 			disabled="[[!_canEdit]]"
 			no-border
 			hover-styles
@@ -57,7 +57,11 @@
 				/**
 				 * textarea aria-label langterm
 				 */
-				ariaLabelText: {
+				ariaLabelLangterm: {
+					type: String,
+					value: ''
+				},
+				criterionName: {
 					type: String,
 					value: ''
 				},
@@ -92,6 +96,11 @@
 				window.D2L.Hypermedia.HMConstantsBehavior,
 				D2L.PolymerBehaviors.Rubric.LocalizeBehavior
 			],
+
+			_getAriaLabel: function(langTerm, criterionName, properties) {
+				var levelName = properties.levelName || properties.name;
+				return this.localize(langTerm, 'criterionName', criterionName, 'levelName', levelName);
+			},
 
 			_getFeedback: function(entity) {
 				var feedback = entity && entity.getSubEntityByClass(this.HypermediaClasses.rubrics.feedback);

--- a/editor/d2l-rubric-feedback-editor.html
+++ b/editor/d2l-rubric-feedback-editor.html
@@ -65,19 +65,7 @@
 					type: String,
 					value: ''
 				},
-				/**
-				 * Index of this level in the collection - useful for aria labels
-				 */
-				levelIndex: String,
-				/**
-				 * Count of levels in the collection - useful for aria labels
-				 */
-				levelCount: Number,
 
-				_levelOffset: {
-					type: Number,
-					computed: '_calcOffset(levelIndex)',
-				},
 				_canEdit: {
 					type: Boolean,
 					computed: '_canEditFeedback(entity)',
@@ -124,10 +112,6 @@
 						this._toggleBubble('_feedbackInvalid', true, this.localize('feedbackSaveFailed'));
 					}.bind(this));
 				}
-			},
-
-			_calcOffset: function(index) {
-				return parseInt(index) + 1;
 			},
 
 			_toggleBubble: function(invalidId, show, error) {

--- a/editor/d2l-rubric-overall-level-editor.html
+++ b/editor/d2l-rubric-overall-level-editor.html
@@ -110,8 +110,7 @@
 						this._toggleBubble('_nameInvalid', true, this.localize('nameIsRequired'));
 					} else {
 						this._toggleBubble('_nameInvalid', false);
-						var fields = new FormData();
-						fields.append('name', e.target.value);
+						var fields = [{ 'name': 'name', 'value': e.target.value }];
 						this.performSirenAction(action, fields).then(function() {
 							this.fire('d2l-rubric-overall-level-saved');
 						}.bind(this)).catch(function() {

--- a/editor/d2l-rubric-overall-levels-editor.html
+++ b/editor/d2l-rubric-overall-levels-editor.html
@@ -191,7 +191,7 @@
 						<d2l-rubric-description-editor
 							href="[[_getSelfLink(overallLevel)]]"
 							token="[[token]]"
-							aria-label-text="[[localize('overallDescriptionAriaLabel', 'levelName', overallLevel.properties.name)]]"
+							aria-label-langterm="overallDescriptionAriaLabel"
 							level-index="[[cellIndex]]"
 							level-count="[[descriptionCount]]"
 						></d2l-rubric-description-editor>
@@ -215,7 +215,7 @@
 						<d2l-rubric-feedback-editor
 							href="[[_getSelfLink(overallLevel)]]"
 							token="[[token]]"
-							aria-label-text="[[localize('overallFeedbackAriaLabel', 'levelName', overallLevel.properties.name)]]"
+							aria-label-langterm="overallFeedbackAriaLabel"
 							level-index="[[cellIndex]]"
 							level-count="[[feedbackCount]]"
 						></d2l-rubric-feedback-editor>

--- a/editor/d2l-rubric-overall-levels-editor.html
+++ b/editor/d2l-rubric-overall-levels-editor.html
@@ -186,14 +186,12 @@
 		<div id="description" class="editor-section">
 			<div class="gutter-left"></div>
 			<div class="col-center">
-				<template is="dom-repeat" items="[[_overallLevels]]" as="overallLevel" index-as="cellIndex" rendered-item-count="{{descriptionCount}}">
+				<template is="dom-repeat" items="[[_overallLevels]]" as="overallLevel">
 					<div class="cell">
 						<d2l-rubric-description-editor
 							href="[[_getSelfLink(overallLevel)]]"
 							token="[[token]]"
 							aria-label-langterm="overallDescriptionAriaLabel"
-							level-index="[[cellIndex]]"
-							level-count="[[descriptionCount]]"
 						></d2l-rubric-description-editor>
 					</div>
 				</template>
@@ -210,14 +208,12 @@
 		<div id="feedback" class="editor-section">
 			<div class="gutter-left"></div>
 			<div class="col-center">
-				<template is="dom-repeat" items="[[_overallLevels]]" as="overallLevel" index-as="cellIndex" rendered-item-count="{{feedbackCount}}">
+				<template is="dom-repeat" items="[[_overallLevels]]" as="overallLevel">
 					<div class="cell">
 						<d2l-rubric-feedback-editor
 							href="[[_getSelfLink(overallLevel)]]"
 							token="[[token]]"
 							aria-label-langterm="overallFeedbackAriaLabel"
-							level-index="[[cellIndex]]"
-							level-count="[[feedbackCount]]"
 						></d2l-rubric-feedback-editor>
 					</div>
 				</template>

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria-criterion-added.js
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria-criterion-added.js
@@ -32,6 +32,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 4"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -81,6 +84,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 3"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -130,6 +136,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 2"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -179,6 +188,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 1"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -250,6 +262,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 4"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -299,6 +314,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 3"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -348,6 +366,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 2"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -397,6 +418,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 1"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -468,6 +492,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 4"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -517,6 +544,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 3"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -566,6 +596,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 2"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -615,6 +648,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 1"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -686,6 +722,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 4"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -735,6 +774,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 3"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -784,6 +826,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 2"
+					},
 					"entities": [{
 						"class": [
 							"richtext",
@@ -833,6 +878,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 1"
+					},
 					"entities": [{
 						"class": [
 							"richtext",

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria-readonly.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria-readonly.json
@@ -23,6 +23,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 4"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -80,6 +83,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 3"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -137,6 +143,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 2"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -194,6 +203,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 1"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -278,6 +290,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 4"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -335,6 +350,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 3"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -392,6 +410,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 2"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -449,6 +470,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 1"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -533,6 +557,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 4"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -590,6 +617,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 3"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -647,6 +677,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 2"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -704,6 +737,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 1"
+                    },
                     "entities": [
                         {
                             "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria.json
@@ -41,6 +41,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 4"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -98,6 +101,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 3"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -155,6 +161,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 2"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -212,6 +221,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 1"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -296,6 +308,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 4"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -353,6 +368,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 3"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -410,6 +428,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 2"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -467,6 +488,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 1"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -551,6 +575,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 4"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -608,6 +635,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 3"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -665,6 +695,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 2"
+                    },
                     "entities": [
                         {
                             "class": [
@@ -722,6 +755,9 @@
                         "item",
                         "https://rubrics.api.brightspace.com/rels/criterion-cell"
                     ],
+                    "properties": {
+                      "levelName": "Level 1"
+                    },
                     "entities": [
                         {
                             "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623-name-mod.js
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623-name-mod.js
@@ -29,6 +29,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 4"
+					},
 					"href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json"
 				},
 				{
@@ -39,6 +42,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 3"
+					},
 					"href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json"
 				},
 				{
@@ -49,6 +55,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 2"
+					},
 					"href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json"
 				},
 				{
@@ -59,6 +68,9 @@ Object.assign(window.testFixtures, {
 						"item",
 						"https://rubrics.api.brightspace.com/rels/criterion-cell"
 					],
+					"properties": {
+						"levelName": "Level 1"
+					},
 					"href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/3.json"
 				}
 			],

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json
@@ -30,6 +30,9 @@
                 "item",
                 "https://rubrics.api.brightspace.com/rels/criterion-cell"
             ],
+            "properties": {
+              "levelName": "Level 4"
+            },
             "entities": [
                 {
                     "class": [
@@ -125,6 +128,9 @@
                 "item",
                 "https://rubrics.api.brightspace.com/rels/criterion-cell"
             ],
+            "properties": {
+              "levelName": "Level 3"
+            },
             "entities": [
                 {
                     "class": [
@@ -182,6 +188,9 @@
                 "item",
                 "https://rubrics.api.brightspace.com/rels/criterion-cell"
             ],
+            "properties": {
+              "levelName": "Level 2"
+            },
             "entities": [
                 {
                     "class": [
@@ -277,6 +286,9 @@
                 "item",
                 "https://rubrics.api.brightspace.com/rels/criterion-cell"
             ],
+            "properties": {
+              "levelName": "Level 1"
+            },
             "entities": [
                 {
                     "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0-description-mod.js
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0-description-mod.js
@@ -8,6 +8,9 @@ Object.assign(window.testFixtures,
 				"class": [
 					"criterion-cell"
 				],
+				"properties": {
+					"levelName": "Level 4"
+				},
 				"entities": [
 					{
 						"class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0-feedback-mod.js
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0-feedback-mod.js
@@ -8,6 +8,9 @@ Object.assign(window.testFixtures,
 				"class": [
 					"criterion-cell"
 				],
+				"properties": {
+					"levelName": "Level 4"
+				},
 				"entities": [
 					{
 						"class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json
@@ -2,6 +2,9 @@
     "class": [
         "criterion-cell"
     ],
+    "properties": {
+      "levelName": "Level 4"
+    },
     "entities": [
         {
             "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json
@@ -2,6 +2,9 @@
     "class": [
         "criterion-cell"
     ],
+    "properties": {
+      "levelName": "Level 3"
+    },
     "entities": [
         {
             "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json
@@ -2,6 +2,9 @@
     "class": [
         "criterion-cell"
     ],
+    "properties": {
+      "levelName": "Level 2"
+    },
     "entities": [
         {
             "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/3.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/3.json
@@ -2,6 +2,9 @@
     "class": [
         "criterion-cell"
     ],
+    "properties": {
+      "levelName": "Level 1"
+    },
     "entities": [
         {
             "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624.json
@@ -14,6 +14,9 @@
                 "item",
                 "https://rubrics.api.brightspace.com/rels/criterion-cell"
             ],
+            "properties": {
+              "levelName": "Level 4"
+            },
             "entities": [
                 {
                     "class": [
@@ -71,6 +74,9 @@
                 "item",
                 "https://rubrics.api.brightspace.com/rels/criterion-cell"
             ],
+            "properties": {
+              "levelName": "Level 3"
+            },
             "entities": [
                 {
                     "class": [
@@ -128,6 +134,9 @@
                 "item",
                 "https://rubrics.api.brightspace.com/rels/criterion-cell"
             ],
+            "properties": {
+              "levelName": "Level 2"
+            },
             "entities": [
                 {
                     "class": [
@@ -185,6 +194,9 @@
                 "item",
                 "https://rubrics.api.brightspace.com/rels/criterion-cell"
             ],
+            "properties": {
+              "levelName": "Level 1"
+            },
             "entities": [
                 {
                     "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/0.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/0.json
@@ -2,6 +2,9 @@
     "class": [
         "criterion-cell"
     ],
+    "properties": {
+      "levelName": "Level 4"
+    },
     "entities": [
         {
             "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/1.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/1.json
@@ -2,6 +2,9 @@
     "class": [
         "criterion-cell"
     ],
+    "properties": {
+      "levelName": "Level 3"
+    },
     "entities": [
         {
             "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/2.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/2.json
@@ -2,6 +2,9 @@
     "class": [
         "criterion-cell"
     ],
+    "properties": {
+      "levelName": "Level 2"
+    },
     "entities": [
         {
             "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/3.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/624/3.json
@@ -2,6 +2,9 @@
     "class": [
         "criterion-cell"
     ],
+    "properties": {
+      "levelName": "Level 1"
+    },
     "entities": [
         {
             "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625.json
@@ -14,6 +14,9 @@
                 "item",
                 "https://rubrics.api.brightspace.com/rels/criterion-cell"
             ],
+            "properties": {
+              "levelName": "Level 4"
+            },
             "entities": [
                 {
                     "class": [
@@ -71,6 +74,9 @@
                 "item",
                 "https://rubrics.api.brightspace.com/rels/criterion-cell"
             ],
+            "properties": {
+              "levelName": "Level 3"
+            },
             "entities": [
                 {
                     "class": [
@@ -128,6 +134,9 @@
                 "item",
                 "https://rubrics.api.brightspace.com/rels/criterion-cell"
             ],
+            "properties": {
+              "levelName": "Level 2"
+            },
             "entities": [
                 {
                     "class": [
@@ -185,6 +194,9 @@
                 "item",
                 "https://rubrics.api.brightspace.com/rels/criterion-cell"
             ],
+            "properties": {
+              "levelName": "Level 1"
+            },
             "entities": [
                 {
                     "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/0.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/0.json
@@ -2,6 +2,9 @@
     "class": [
         "criterion-cell"
     ],
+    "properties": {
+      "levelName": "Level 4"
+    },
     "entities": [
         {
             "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/1.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/1.json
@@ -2,6 +2,9 @@
     "class": [
         "criterion-cell"
     ],
+    "properties": {
+      "levelName": "Level 3"
+    },
     "entities": [
         {
             "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/2.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/2.json
@@ -2,6 +2,9 @@
     "class": [
         "criterion-cell"
     ],
+    "properties": {
+      "levelName": "Level 2"
+    },
     "entities": [
         {
             "class": [

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/3.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/625/3.json
@@ -2,6 +2,9 @@
     "class": [
         "criterion-cell"
     ],
+    "properties": {
+      "levelName": "Level 1"
+    },
     "entities": [
         {
             "class": [


### PR DESCRIPTION
The first commit allows aria labels to update when level names or criteria names are updated.
The second commit fixes a bug that didn't push hidden fields correctly when updating overall level name.
The third commit removes properties that were previously used to aria-label the rubric cells, but are no longer used.