### PR TITLE
fix overall level add button focus border getting cut off

### DIFF
--- a/editor/d2l-rubric-overall-levels-editor.html
+++ b/editor/d2l-rubric-overall-levels-editor.html
@@ -35,6 +35,10 @@
 				margin-right: 0;
 				margin-left: calc(var(--d2l-rubric-editor-gutter-width) - 0.3rem);
 			}
+			.gutter-left, .gutter-right {
+				margin-top: 11px;
+				margin-bottom: 11px;
+			}
 			.editor-section {
 				display: flex;
 				flex-direction: row;


### PR DESCRIPTION
Fixes https://trello.com/c/uj4AoZvy/6-blue-border-slightly-cut-off-top-bottom-after-clicking-add-level-button-on-overall-score