### PR TITLE
Display criterion out-of value as text

### DIFF
--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -88,6 +88,12 @@
 				padding: 0;
 			}
 
+			.out-of {
+				display: flex;
+				justify-content: center;
+				padding-top: 1.4rem;
+			}
+
 			.criterion-detail .criterion-feedback-header {
 				@apply --d2l-body-compact-text;
 				flex: 0 0 auto;
@@ -170,7 +176,12 @@
 				</template>
 			</div>
 		</div>
-		<div text-only$="[[!hasOutOf]]" class="cell col-last"><span hidden="[[!hasOutOf]]">/ <d2l-text-input value="" aria-label="todo" prevent-submit></d2l-text-input></span></div>
+		<div text-only$="[[!hasOutOf]]" class="cell col-last out-of">
+			<span hidden="[[!hasOutOf]]" aria-label$="[[localize('criterionOutOf', 'name', entity.properties.name, 'value', outOf)]]">
+				[[_formatOutOf(outOf)]]
+				<!-- <d2l-text-input value=[[outOf]] aria-label="todo" prevent-submit></d2l-text-input> -->
+			</span>
+		</div>
 		<div class="gutter-right" text-only$="[[!hasOutOf]]">
 			<d2l-button-icon
 				id="remove"
@@ -208,6 +219,10 @@
 				hasOutOf: {
 					type: Boolean,
 					value: false
+				},
+				outOf: {
+					type: Number,
+					computed: '_getOutOfValue(entity)',
 				},
 				displayNamePlaceholder: {
 					type: Boolean,
@@ -313,8 +328,20 @@
 						this.fire('d2l-rubric-criterion-deleted');
 					}.bind(this));
 				}
-			}
+			},
 
+			_getOutOfValue: function(entity) {
+				if (this.hasOutOf) {
+					var action = entity.getActionByName("update");
+					if (action && action.fields[1] && action.fields[1].name === "outOf") {
+						return action.fields[1].value;
+					}
+				}
+			},
+
+			_formatOutOf: function(outOf) {
+				return "/ " + outOf;
+			}
 		});
 	</script>
 </dom-module>

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -347,13 +347,8 @@
 					var action = entity.getActionByName("update");
 					if (!action) return false;
 					var field = action.getFieldByName("outOf");
-					if (field) {
-						for (var i = 0; i < field.class.length; i++) {
-							if (field.class[i] === "readonly") return false;
-						}
-						return true;
-					}
-					return false;
+					if (!field || (field && field.hasClass("readonly"))) return false;
+					return true;
 				}
 			}
 		});

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -177,9 +177,13 @@
 			</div>
 		</div>
 		<div text-only$="[[!hasOutOf]]" class="cell col-last out-of">
-			<span hidden="[[!hasOutOf]]" aria-label$="[[localize('criterionOutOf', 'name', entity.properties.name, 'value', outOf)]]">
-				[[_formatOutOf(outOf)]]
-				<!-- <d2l-text-input value=[[outOf]] aria-label="todo" prevent-submit></d2l-text-input> -->
+			<span hidden="[[!hasOutOf]]" aria-label$="[[localize('criterionOutOf', 'name', entity.properties.name, 'value', _outOf)]]">
+				<template is="dom-if" if="[[!_outOfIsEditable]]">
+					/ [[_outOf]]
+				</template>
+				<template is="dom-if" if="[[_outOfIsEditable]]">
+					/ <d2l-text-input value="" aria-label="todo" prevent-submit></d2l-text-input>
+				</template>
 			</span>
 		</div>
 		<div class="gutter-right" text-only$="[[!hasOutOf]]">
@@ -220,7 +224,11 @@
 					type: Boolean,
 					value: false
 				},
-				outOf: {
+				_outOfIsEditable: {
+					type: Boolean,
+					computed: '_isOutOfEditable(entity)'
+				},
+				_outOf: {
 					type: Number,
 					computed: '_getOutOfValue(entity)',
 				},
@@ -331,16 +339,23 @@
 			},
 
 			_getOutOfValue: function(entity) {
-				if (this.hasOutOf) {
-					var action = entity.getActionByName("update");
-					if (action && action.fields[1] && action.fields[1].name === "outOf") {
-						return action.fields[1].value;
-					}
-				}
+				if (this.hasOutOf) return entity.properties.outOf;
 			},
 
-			_formatOutOf: function(outOf) {
-				return "/ " + outOf;
+			_isOutOfEditable: function(entity) {
+				if (this.hasOutOf) {
+					var action = entity.getActionByName("update");
+					for (var i = 0; i < action.fields.length; i++) {
+						if (action.fields[i].name === "outOf") {
+							var outOfField = action.fields[i];
+							for (var i = 0; i < outOfField.class.length; i++) {
+								if (outOfField.class[i] === "readonly") return false;
+							}
+							return true;
+						}
+					}
+					return false;
+				}
 			}
 		});
 	</script>

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -345,14 +345,13 @@
 			_isOutOfEditable: function(entity) {
 				if (this.hasOutOf) {
 					var action = entity.getActionByName("update");
-					for (var i = 0; i < action.fields.length; i++) {
-						if (action.fields[i].name === "outOf") {
-							var outOfField = action.fields[i];
-							for (var i = 0; i < outOfField.class.length; i++) {
-								if (outOfField.class[i] === "readonly") return false;
-							}
-							return true;
+					if (!action) return false;
+					var field = action.getFieldByName("outOf");
+					if (field) {
+						for (var i = 0; i < field.class.length; i++) {
+							if (field.class[i] === "readonly") return false;
 						}
+						return true;
 					}
 					return false;
 				}

--- a/lang/ar.html
+++ b/lang/ar.html
@@ -26,6 +26,7 @@
 			'criterionDescriptionAriaLabel': 'Description for criterion {criterionName}, level {levelName}',
 			'criterionFeedbackAriaLabel': 'Feedback for criterion {criterionName}, level {levelName}',
 			'criterionNameAriaLabel': 'Criterion name',
+			'criterionOutOf': 'Criterion {name} is out of {value} points',
 			'criterionPlaceholder': 'Click to edit criterion',
 			'dashOutOf': '\u2014 / {outOf}',
 			'descriptionSaveFailed': 'Saving description failed',

--- a/lang/de.html
+++ b/lang/de.html
@@ -26,6 +26,7 @@
 			'criterionDescriptionAriaLabel': 'Description for criterion {criterionName}, level {levelName}',
 			'criterionFeedbackAriaLabel': 'Feedback for criterion {criterionName}, level {levelName}',
 			'criterionNameAriaLabel': 'Criterion name',
+			'criterionOutOf': 'Criterion {name} is out of {value} points',
 			'criterionPlaceholder': 'Click to edit criterion',
 			'dashOutOf': '\u2014 / {outOf}',
 			'descriptionSaveFailed': 'Saving description failed',

--- a/lang/en.html
+++ b/lang/en.html
@@ -27,6 +27,7 @@
 			'criterionDescriptionAriaLabel': 'Description for criterion {criterionName}, level {levelName}',
 			'criterionFeedbackAriaLabel': 'Feedback for criterion {criterionName}, level {levelName}',
 			'criterionNameAriaLabel': 'Criterion name',
+			'criterionOutOf': 'Criterion {name} is out of {value} points',
 			'criterionPlaceholder': 'Click to edit criterion',
 			'dashOutOf': '\u2014 / {outOf}',
 			'descriptionSaveFailed': 'Saving description failed',

--- a/lang/es.html
+++ b/lang/es.html
@@ -26,6 +26,7 @@
 			'criterionDescriptionAriaLabel': 'Description for criterion {criterionName}, level {levelName}',
 			'criterionFeedbackAriaLabel': 'Feedback for criterion {criterionName}, level {levelName}',
 			'criterionNameAriaLabel': 'Criterion name',
+			'criterionOutOf': 'Criterion {name} is out of {value} points',
 			'criterionPlaceholder': 'Click to edit criterion',
 			'dashOutOf': '\u2014 / {outOf}',
 			'descriptionSaveFailed': 'Saving description failed',

--- a/lang/fr.html
+++ b/lang/fr.html
@@ -26,6 +26,7 @@
 			'criterionDescriptionAriaLabel': 'Description for criterion {criterionName}, level {levelName}',
 			'criterionFeedbackAriaLabel': 'Feedback for criterion {criterionName}, level {levelName}',
 			'criterionNameAriaLabel': 'Criterion name',
+			'criterionOutOf': 'Criterion {name} is out of {value} points',
 			'criterionPlaceholder': 'Click to edit criterion',
 			'dashOutOf': '\u2014 / {outOf}',
 			'descriptionSaveFailed': 'Saving description failed',

--- a/lang/ja.html
+++ b/lang/ja.html
@@ -26,6 +26,7 @@
 			'criterionDescriptionAriaLabel': 'Description for criterion {criterionName}, level {levelName}',
 			'criterionFeedbackAriaLabel': 'Feedback for criterion {criterionName}, level {levelName}',
 			'criterionNameAriaLabel': 'Criterion name',
+			'criterionOutOf': 'Criterion {name} is out of {value} points',
 			'criterionPlaceholder': 'Click to edit criterion',
 			'dashOutOf': '\u2014 / {outOf}',
 			'descriptionSaveFailed': 'Saving description failed',

--- a/lang/ko.html
+++ b/lang/ko.html
@@ -26,6 +26,7 @@
 			'criterionDescriptionAriaLabel': 'Description for criterion {criterionName}, level {levelName}',
 			'criterionFeedbackAriaLabel': 'Feedback for criterion {criterionName}, level {levelName}',
 			'criterionNameAriaLabel': 'Criterion name',
+			'criterionOutOf': 'Criterion {name} is out of {value} points',
 			'criterionPlaceholder': 'Click to edit criterion',
 			'dashOutOf': '\u2014 / {outOf}',
 			'descriptionSaveFailed': 'Saving description failed',

--- a/lang/nl.html
+++ b/lang/nl.html
@@ -26,6 +26,7 @@
 			'criterionDescriptionAriaLabel': 'Description for criterion {criterionName}, level {levelName}',
 			'criterionFeedbackAriaLabel': 'Feedback for criterion {criterionName}, level {levelName}',
 			'criterionNameAriaLabel': 'Criterion name',
+			'criterionOutOf': 'Criterion {name} is out of {value} points',
 			'criterionPlaceholder': 'Click to edit criterion',
 			'dashOutOf': '\u2014 / {outOf}',
 			'descriptionSaveFailed': 'Saving description failed',

--- a/lang/pt.html
+++ b/lang/pt.html
@@ -26,6 +26,7 @@
 			'criterionDescriptionAriaLabel': 'Description for criterion {criterionName}, level {levelName}',
 			'criterionFeedbackAriaLabel': 'Feedback for criterion {criterionName}, level {levelName}',
 			'criterionNameAriaLabel': 'Criterion name',
+			'criterionOutOf': 'Criterion {name} is out of {value} points',
 			'criterionPlaceholder': 'Click to edit criterion',
 			'dashOutOf': '\u2014 / {outOf}',
 			'descriptionSaveFailed': 'Saving description failed',

--- a/lang/sv.html
+++ b/lang/sv.html
@@ -26,6 +26,7 @@
 			'criterionDescriptionAriaLabel': 'Description for criterion {criterionName}, level {levelName}',
 			'criterionFeedbackAriaLabel': 'Feedback for criterion {criterionName}, level {levelName}',
 			'criterionNameAriaLabel': 'Criterion name',
+			'criterionOutOf': 'Criterion {name} is out of {value} points',
 			'criterionPlaceholder': 'Click to edit criterion',
 			'dashOutOf': '\u2014 / {outOf}',
 			'descriptionSaveFailed': 'Saving description failed',

--- a/lang/tr.html
+++ b/lang/tr.html
@@ -26,6 +26,7 @@
 			'criterionDescriptionAriaLabel': 'Description for criterion {criterionName}, level {levelName}',
 			'criterionFeedbackAriaLabel': 'Feedback for criterion {criterionName}, level {levelName}',
 			'criterionNameAriaLabel': 'Criterion name',
+			'criterionOutOf': 'Criterion {name} is out of {value} points',
 			'criterionPlaceholder': 'Click to edit criterion',
 			'dashOutOf': '\u2014 / {outOf}',
 			'descriptionSaveFailed': 'Saving description failed',

--- a/lang/zh-tw.html
+++ b/lang/zh-tw.html
@@ -26,6 +26,7 @@
 			'criterionDescriptionAriaLabel': 'Description for criterion {criterionName}, level {levelName}',
 			'criterionFeedbackAriaLabel': 'Feedback for criterion {criterionName}, level {levelName}',
 			'criterionNameAriaLabel': 'Criterion name',
+			'criterionOutOf': 'Criterion {name} is out of {value} points',
 			'criterionPlaceholder': 'Click to edit criterion',
 			'dashOutOf': '\u2014 / {outOf}',
 			'descriptionSaveFailed': 'Saving description failed',

--- a/lang/zh.html
+++ b/lang/zh.html
@@ -26,6 +26,7 @@
 			'criterionDescriptionAriaLabel': 'Description for criterion {criterionName}, level {levelName}',
 			'criterionFeedbackAriaLabel': 'Feedback for criterion {criterionName}, level {levelName}',
 			'criterionNameAriaLabel': 'Criterion name',
+			'criterionOutOf': 'Criterion {name} is out of {value} points',
 			'criterionPlaceholder': 'Click to edit criterion',
 			'dashOutOf': '\u2014 / {outOf}',
 			'descriptionSaveFailed': 'Saving description failed',


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/detail/task/251038054796
![outof](https://user-images.githubusercontent.com/32819802/45060735-276e0d80-b056-11e8-8e52-4db29b8c4a34.png)
This will only be functional after the LMS change to modify the criterion `update` action goes in, since it was decided not to read the value from the property: https://git.dev.d2l/projects/CORE/repos/lp/pull-requests/10716/overview