### PR TITLE
Fixed score overrides to work on non-Chrome browsers

### DIFF
--- a/assessment-result-behavior.html
+++ b/assessment-result-behavior.html
@@ -222,7 +222,7 @@
 			}
 			var fields = action.fields;
 			var assessmentField = fields.find(function(field) { return field.name === 'rubricAssessment'; });
-			return assessmentField.value.OverallScoreOverridden;
+			return assessmentField.value.TotalScoreOverridden;
 		},
 
 		saveCriterionPoints: function(criterionHref, points) {

--- a/assessment-result-behavior.html
+++ b/assessment-result-behavior.html
@@ -256,7 +256,7 @@
 				var fields = action.fields;
 				var assessmentField = fields.find(function(field) { return field.name === 'rubricAssessment'; });
 				assessmentField.value.OverallScore = points;
-				assessmentField.value.OverallScoreOverridden = true;
+				assessmentField.value.TotalScoreOverridden = true;
 				this.performSirenAction(action, fields);
 			}
 		},

--- a/d2l-rubric-criteria-group.html
+++ b/d2l-rubric-criteria-group.html
@@ -494,9 +494,6 @@
 				}
 				var criterionNum = event.model.get('criterionNum');
 				this.editingScore = criterionNum;
-				fastdom.mutate(function() {
-					Polymer.dom(this.root).querySelector('#score-inner' + criterionNum).focus();
-				}.bind(this));
 			}
 		});
 	</script>

--- a/d2l-rubric-editable-score.html
+++ b/d2l-rubric-editable-score.html
@@ -42,6 +42,7 @@
 				step="any"
 				min="0"
 				max="100000"
+				on-blur="_blurHandler"
 			>
 			</d2l-text-input>
 			<div class="right">[[_localizeOutOf(entity)]]</div>
@@ -67,19 +68,14 @@
 					value: null
 				},
 				token: String,
-				_boundBlurHandler: {
-					type: Function,
-					value: function() {
-						return this._blurHandler.bind(this);
-					}
-				},
 
 				/* For desktop criteria, this will be the criterion number.
 				   For mobile and total score, this will be 1 for true, -1 for false */
 				editingScore: {
 					type: Number,
 					value: -1,
-					notify: true
+					notify: true,
+					observer: '_editingScoreChanged'
 				},
 				scoreOverridden: {
 					type: Boolean,
@@ -121,23 +117,17 @@
 				this.scoreOverridden = this.isScoreOverridden(this.criterionHref);
 			},
 
-			attached: function() {
-				var elem = Polymer.dom(this.root).querySelector('d2l-text-input');
-				if (!elem) {
-					return;
-				}
-				elem.addEventListener('blur', this._boundBlurHandler);
-			},
-
-			detached: function() {
-				var elem = Polymer.dom(this.root).querySelector('d2l-text-input');
-				if (!elem) return;
-				elem.removeEventListener('blur', this._boundBlurHandler);
-			},
-
 			focus: function() {
 				var elem = Polymer.dom(this.root).querySelector('d2l-text-input');
 				elem.focus();
+			},
+
+			_editingScoreChanged: function(newValue) {
+				if (this._isEditingScore(this.criterionNum, newValue)) {
+					Polymer.RenderStatus.afterNextRender(this, function() {
+						this.focus();
+					}.bind(this));
+				}
 			},
 
 			_blurHandler: function(event) {

--- a/d2l-rubric-levels-mobile.html
+++ b/d2l-rubric-levels-mobile.html
@@ -390,9 +390,6 @@
 					return;
 				}
 				this.editingScore = 1;
-				fastdom.mutate(function() {
-					Polymer.dom(this.root).querySelector('#score-inner').focus();
-				}.bind(this));
 			},
 
 			_isEditingScore: function(editingScore) {

--- a/d2l-rubric.html
+++ b/d2l-rubric.html
@@ -382,9 +382,6 @@ Polymer Web-Component to display rubrics
 					return;
 				}
 				this.editingScore = 1;
-				fastdom.mutate(function() {
-					Polymer.dom(this.root).querySelector('#total-score-inner').focus();
-				}.bind(this));
 			}
 		});
 	</script>


### PR DESCRIPTION
* Simplified binding of blur event handler
* Defer focusing the text input box until we know it is actually rendered to avoid an immediate blur event in most browsers
* Trigger the focus automatically when the `editing-score` property changes instead of explicitly calling it

This PR fixes the score overrides being broken on non-Chrome browsers, as well as the total score not updating when changed.