### PR TITLE
Mbayly/editor horiz scrolling

### DIFF
--- a/editor/d2l-rubric-criteria-editor.html
+++ b/editor/d2l-rubric-criteria-editor.html
@@ -16,6 +16,7 @@
 		<style include="d2l-rubric-editor-cell-styles">
 			:host {
 				display: block;
+				flex: 1 1 auto;
 			}
 
 			* {

--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../d2l-table/d2l-table-shared-styles.html">
+<link rel="import" href="../../d2l-table/d2l-scroll-wrapper.html">
 <link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../../d2l-alert/d2l-alert.html">
 <link rel="import" href="../../d2l-tooltip/d2l-tooltip.html">
@@ -15,6 +16,20 @@
 		<style>
 			:host {
 				display: block;
+				--d2l-scroll-wrapper-background-color: var(--d2l-table-header-background-color);
+				--d2l-scroll-wrapper-border-color: var(--d2l-table-border-color);
+
+				--d2l-scroll-wrapper-h-scroll: {
+					overflow-x: hidden;
+				};
+
+				--d2l-scroll-wrapper-left: {
+					overflow-x: hidden;
+				};
+
+				--d2l-scroll-wrapper-right: {
+					overflow-x: hidden;
+				};
 			}
 
 			* {
@@ -40,40 +55,61 @@
 			[hidden] {
 				display: none;
 			}
+
+			.stretch-child {
+				display: flex;
+			}
 		</style>
-
-		<template is="dom-repeat" items="[[_alerts]]">
-			<d2l-alert type="[[item.alertType]]" has-close-button>
-				[[item.alertMessage]]
-			</d2l-alert>
-		</template>
-
-		<div class="criteria-group" role="region" aria-label$="[[localize('groupRegion', 'name', _groupName)]]">
-			<d2l-rubric-loading hidden$="[[_showContent]]"></d2l-rubric-loading>
-			<d2l-rubric-levels-editor
-				href="[[_levelsHref]]"
-				token="[[token]]"
-				has-out-of="[[_hasOutOf(entity)]]">
-				<d2l-text-input
-					id="group-name"
-					slot="group-name-slot"
-					value="[[_groupName]]"
-					hidden="[[!showGroupName]]"
-					disabled="[[!_canEditGroupName(entity)]]"
-					on-change="_saveName"
-					aria-label$="[[localize('groupName')]]"
-					required prevent-submit>
-				</d2l-text-input>
-			</d2l-rubric-levels-editor>
-			<template is="dom-if" if="[[_nameInvalid]]">
-				<d2l-tooltip for="group-name" position="bottom">[[_nameInvalidError]]</d2l-tooltip>
+		<d2l-scroll-wrapper
+			id="scroll-wrapper"
+			scroll-duration="500"
+			scroll-amount="0.2"
+			start-icon="d2l-tier1:chevron-left"
+			end-icon="d2l-tier1:chevron-right"
+			show-actions
+		>
+			<template is="dom-repeat" items="[[_alerts]]">
+				<d2l-alert type="[[item.alertType]]" has-close-button>
+					[[item.alertMessage]]
+				</d2l-alert>
 			</template>
-			<d2l-rubric-criteria-editor
-				href="[[_criteriaCollectionHref]]"
-				token="[[token]]"
-				has-out-of="[[_hasOutOf(entity)]]">
-			</d2l-rubric-criteria-editor>
-		</div>
+			<div class="criteria-group" role="region" aria-label$="[[localize('groupRegion', 'name', _groupName)]]">
+				<d2l-rubric-loading hidden$="[[_showContent]]"></d2l-rubric-loading>
+				<d2l-rubric-levels-editor
+					href="[[_levelsHref]]"
+					token="[[token]]"
+					has-out-of="[[_hasOutOf(entity)]]"
+					on-d2l-siren-entity-changed="_notifyResize">
+					<d2l-text-input
+						id="group-name"
+						slot="group-name-slot"
+						value="[[_groupName]]"
+						hidden="[[!showGroupName]]"
+						disabled="[[!_canEditGroupName(entity)]]"
+						on-change="_saveName"
+						aria-label$="[[localize('groupName')]]"
+						required prevent-submit>
+					</d2l-text-input>
+				</d2l-rubric-levels-editor>
+				<template is="dom-if" if="[[_nameInvalid]]">
+					<d2l-tooltip for="group-name" position="bottom">[[_nameInvalidError]]</d2l-tooltip>
+				</template>
+				<!--
+				This flex wrapper div is required to ensure that the d2l-rubric-criteria-editor
+				fills the full width of it's parent when the d2l-rubric-criterion-editor components overflow.
+				This ensures that the criteria footer which encapsulates the Add Criteria button
+				also stretches to utilize all the available space, particularly when we are shrinking
+				the size of the editor
+				-->
+				<div class="stretch-child">
+					<d2l-rubric-criteria-editor
+						href="[[_criteriaCollectionHref]]"
+						token="[[token]]"
+						has-out-of="[[_hasOutOf(entity)]]">
+					</d2l-rubric-criteria-editor>
+				</div>
+			</div>
+		</d2l-scroll-wrapper>
 	</template>
 
 	<script>
@@ -171,6 +207,12 @@
 					this.set(invalidId, false);
 				}
 			},
+
+			_notifyResize: function() {
+				Polymer.RenderStatus.afterNextRender(this.$$('d2l-rubric-levels-editor'), function() {
+					this.$$('d2l-scroll-wrapper').notifyResize();
+				}.bind(this));
+			}
 		});
 	</script>
 </dom-module>

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -96,8 +96,7 @@
 			}
 
 			.col-last[text-only] {
-				min-width: calc(1rem + 2.2rem); /* button width = 44px including border */
-				flex: 0 0 0%;
+				width: calc(1rem + 2.2rem); /* button width = 44px including border */
 			}
 
 			.col-last d2l-text-input {

--- a/editor/d2l-rubric-editor-cell-styles.html
+++ b/editor/d2l-rubric-editor-cell-styles.html
@@ -11,13 +11,10 @@
 		.cell {
 			border-left: var(--d2l-table-border);
 			border-top: var(--d2l-table-border);
-			padding: 1rem;
 			flex: 1 1 0%;
-			/*
-			text-input min width is 2rem + 1em, so adding cell padding to this to give cell min-width
-			This is needed to enforce the same min-width on text input and text area cells
-			*/
-			min-width: calc(2rem + 1em + 2rem);
+			/* Min width chosen so that 4 levels are visible in standard LMS tab layout.
+			After 4 levels scrolling will kick in */
+			min-width: 8rem;
 		}
 
 		:host-context([dir="rtl"]) .cell {
@@ -26,20 +23,16 @@
 		}
 
 		.gutter-left, .gutter-right {
-			flex-shrink: 0;
-			flex-grow: 0;
-			flex-basis: auto;
+			flex: 0 0 auto;
 			width: var(--d2l-rubric-editor-gutter-width);
 			padding: 0;
 			text-align: center;
 		}
 
 		.col-first {
-			flex-shrink: 0;
-			flex-grow: 0;
-			flex-basis: auto;
-			width: 23%;
-			min-width: 7rem;
+			flex: 0 0 auto;
+			width: 10.5rem;
+			min-width: auto;
 			padding: 0;
 		}
 
@@ -49,7 +42,7 @@
 
 		.col-last {
 			flex: 0 0 auto;
-			min-width: 6rem;
+			min-width: auto;
 			border-right: var(--d2l-table-border);
 		}
 

--- a/editor/d2l-rubric-levels-editor.html
+++ b/editor/d2l-rubric-levels-editor.html
@@ -16,7 +16,6 @@
 				display: flex;
 				flex-direction: row;
 				justify-content: space-between;
-				overflow: hidden;
 			}
 
 			* {
@@ -57,8 +56,7 @@
 				border-top-left-radius: var(--d2l-table-border-radius);;
 			}
 			.col-last[noOutOf] {
-				min-width: calc(1rem + 44px); /* button width = 44px including border */
-				flex: 0 0 0%;
+				width: calc(1rem + 2.2rem); /* button width = 44px including border */
 			}
 		</style>
 


### PR DESCRIPTION
This PR integrates the d2l-scroll-wrapper from d2l-table to enable a 'fancy' style of horizontal scrolling when there are too many levels to fit in the space allocated to the editor.

I had to tweak how to remove how we set the variable width on the criterion name, as I could not make this play nicely with the scrolling. I verified with Joseph, and the current width is what we agreed. 

I also replaced some of the min-widths we had been using on the first and last columns to use explicit `width` properties instead, as this is actually what we are intending for those columns (we don't expect them to resize as the window is resized and they never did anyway because of the way the flex properties are configured.

The scroll-wrapper is a bit flaky at times in that the buttons (mostly the right hand button) doesn't disappear correctly. This seems to be due to rounding errors with the way it is calculating the scroll offsets and will most likely need a fix to d2l-scroll-wrapper to resolve.

@mdulat @emil-furniss If you are setting any min-widths on the levels/criterion last columns for supporting points rubrics, I suggest you switch to using just a regular `width` property as well. 