### PR TITLE
US96676 Handle level patch errors

### DIFF
--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -172,8 +172,13 @@
 
 			_handleSaveError: function(e) {
 				this._clearAlerts();
-				this.fire('iron-announce', { text: this.localize('rubricSavingErrorAriaAlert') }, { bubbles: true });
-				this._addAlert('error', e.detail.error.message, this.localize('rubricSavingErrorMessage'));
+				// only handle generic errors (without details)
+				try {
+					var errObj = e.detail.error.string ? e.detail.error.string.properties : e.detail.error.json.properties;
+				} catch(err) {
+					this.fire('iron-announce', { text: this.localize('rubricSavingErrorAriaAlert') }, { bubbles: true });
+					this._addAlert('error', e.detail.error.message, this.localize('rubricSavingErrorMessage'));
+				}
 			},
 
 			_canEditGroupName: function(entity) {

--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -173,12 +173,14 @@
 			_handleSaveError: function(e) {
 				this._clearAlerts();
 				// only handle generic errors (without details)
-				try {
-					var errObj = e.detail.error.string ? e.detail.error.string.properties : e.detail.error.json.properties;
-				} catch(err) {
-					this.fire('iron-announce', { text: this.localize('rubricSavingErrorAriaAlert') }, { bubbles: true });
-					this._addAlert('error', e.detail.error.message, this.localize('rubricSavingErrorMessage'));
+				if (!e.detail.error.hasOwnProperty('stack')) {
+					var errObj = e.detail.error.string ? e.detail.error.string : e.detail.error.json;
+					if (errObj.hasOwnProperty('properties')) {
+						return;
+					}
 				}
+				this.fire('iron-announce', { text: this.localize('rubricSavingErrorAriaAlert') }, { bubbles: true });
+				this._addAlert('error', e.detail.error.message, this.localize('rubricSavingErrorMessage'));
 			},
 
 			_canEditGroupName: function(entity) {

--- a/editor/d2l-rubric-level-editor.html
+++ b/editor/d2l-rubric-level-editor.html
@@ -195,10 +195,13 @@
 				}
 			},
 			_getErrMsg: function(e, altMsg) {
-				if (e.stack) {
-					return this.localize(altMsg);
+				if (!e.hasOwnProperty('stack')) {
+					var errObj = e.string ? e.string : e.json;
+					if (errObj.hasOwnProperty('properties')) {
+						return errObj.properties.detail;
+					}
 				}
-				return e.json ? e.json.properties.detail : e.string.properties.detail;
+				return this.localize(altMsg);
 			},
 			_toggleBubble: function(invalidId, show, error) {
 				if (show) {

--- a/editor/d2l-rubric-level-editor.html
+++ b/editor/d2l-rubric-level-editor.html
@@ -172,8 +172,8 @@
 						var fields = [{'name':'name', 'value':e.target.value}];
 						this.performSirenAction(action, fields).then(function() {
 							this.fire('d2l-rubric-level-saved');
-						}.bind(this)).catch(function() {
-							this._toggleBubble('_nameInvalid', true, this.localize('nameSaveFailed'));
+						}.bind(this)).catch(function(e) {
+							this._toggleBubble('_nameInvalid', true, this._getErrMsg(e,'nameSaveFailed'));
 						}.bind(this));
 					}
 				}
@@ -188,11 +188,17 @@
 						var fields = [{'name':'points', 'value':e.target.value}];
 						this.performSirenAction(action, fields).then(function() {
 							this.fire('d2l-rubric-level-points-saved');
-						}.bind(this)).catch(function() {
-							this._toggleBubble('_pointsInvalid', true, this.localize('pointsSaveFailed'));
+						}.bind(this)).catch(function(e) {
+							this._toggleBubble('_pointsInvalid', true, this._getErrMsg(e,'pointsSaveFailed'));
 						}.bind(this));
 					}
 				}
+			},
+			_getErrMsg: function(e, altMsg) {
+				if (e.stack) {
+					return this.localize(altMsg);
+				}
+				return e.json ? e.json.properties.detail : e.string.properties.detail;
 			},
 			_toggleBubble: function(invalidId, show, error) {
 				if (show) {
@@ -202,8 +208,8 @@
 					this.set(invalidId, false);
 				}
 			},
-			_isAriaInvalid: function(nameInvalid) {
-				return new Boolean(nameInvalid).toString();
+			_isAriaInvalid: function(valueInvalid) {
+				return new Boolean(valueInvalid).toString();
 			},
 			_canDeleteLevel: function(entity) {
 				return entity && entity.hasActionByName('delete');

--- a/test/components/d2l-rubric-criteria-editor.js
+++ b/test/components/d2l-rubric-criteria-editor.js
@@ -125,6 +125,10 @@ suite('<d2l-rubric-criteria-editor>', function() {
 				element.token = 'foozleberries';
 			});
 
+			teardown(function() {
+				window.D2L.Siren.EntityStore.clear();
+			});
+
 			test('add is disabled', function() {
 				var addButton = element.$$('d2l-button-subtle');
 				expect(addButton.disabled).to.be.true;

--- a/test/components/d2l-rubric-criteria-group-editor.js
+++ b/test/components/d2l-rubric-criteria-group-editor.js
@@ -72,7 +72,9 @@ suite('<d2l-rubric-criteria-group-editor>', function() {
 				var promise = Promise.resolve({
 					ok: false,
 					json: function() {
-						return Promise.resolve(JSON.stringify({}));
+						return Promise.resolve(JSON.stringify(
+							{'class':['error'], 'properties':{'status':'BadRequest', 'code':400, 'type':'https://rubrics.api.brightspace.com/rels/errors/invalid-number-points-error', 'title':'InvalidNumberPointsError', 'detail':'Point value must be a valid number'}}
+						));
 					}
 				});
 				fetch.returns(promise);
@@ -82,7 +84,7 @@ suite('<d2l-rubric-criteria-group-editor>', function() {
 				element.$$('#group-name').dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: false, composed: true }));
 			});
 		});
-		
+
 		suite('readonly', function() {
 			var element;
 
@@ -97,20 +99,20 @@ suite('<d2l-rubric-criteria-group-editor>', function() {
 				element.addEventListener('d2l-siren-entity-changed', waitForLoad);
 				element.token = 'foozleberries';
 			});
-			
+
 			test('group name is disabled', function() {
 				expect(element.$$('#group-name').disabled).to.be.true;
 			});
 		});
 	});
 
-	suite ('Ally Test',function(){
+	suite ('Ally Test', function(){
 		suiteSetup(function(){
 			if (!isAttestInstalled()){
 				this.skip();
 			}
 		});
-        test('d2l-rubric-criteria-group-editor ally checks',function(){
+        test('d2l-rubric-criteria-group-editor ally checks', function(){
 			return ally_tests();
 		});
     });

--- a/test/components/d2l-rubric-level-editor.js
+++ b/test/components/d2l-rubric-level-editor.js
@@ -90,17 +90,64 @@ suite('<d2l-rubric-level-editor>', function() {
 				});
 			});
 
+			test('generates event if saving points fails', function(done) {
+				fetch = sinon.stub(window.d2lfetch, 'fetch');
+				var promise = Promise.resolve({
+					ok: false,
+					json: function() {
+						return Promise.resolve(JSON.stringify({
+							'class':['error'], 'properties':{'status':'BadRequest', 'code':400, 'type':'https://rubrics.api.brightspace.com/rels/errors/invalid-number-points-error', 'title':'InvalidNumberPointsError', 'detail':'Point value must be a valid number'}
+						}));
+					}
+				});
+				fetch.returns(promise);
+
+				var pointsInput = element.$$('#level-points');
+				pointsInput.value = 'abc';
+				element.addEventListener('d2l-siren-entity-save-error', function() {
+					done();
+				});
+				pointsInput.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: false, composed: true }));
+			});
+
+			test('sets aria-invalid if saving points fails', function(done) {
+				fetch = sinon.stub(window.d2lfetch, 'fetch');
+				var promise = Promise.resolve({
+					ok: false,
+					json: function() {
+						return Promise.resolve(JSON.stringify({
+							'class':['error'], 'properties':{'status':'BadRequest', 'code':400, 'type':'https://rubrics.api.brightspace.com/rels/errors/invalid-number-points-error', 'title':'InvalidNumberPointsError', 'detail':'Point value must be a valid number'}
+						}));
+					}
+				});
+				fetch.returns(promise);
+
+				var nameTextInput = element.$$('#level-points');
+				nameTextInput.value = 'abc';
+				raf(function() {
+					element.addEventListener('d2l-siren-entity-save-error', function() {
+						flush(function() {
+							expect(nameTextInput.ariaInvalid).to.equal('true');
+							done();
+						});
+					});
+					nameTextInput.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: false, composed: true }));
+				});
+			});
+
 			test('sets aria-invalid if saving name fails', function(done) {
 				fetch = sinon.stub(window.d2lfetch, 'fetch');
 				var promise = Promise.resolve({
 					ok: false,
 					json: function() {
-						return Promise.resolve(JSON.stringify({}));
+						return Promise.resolve(JSON.stringify({
+							'class':['error'], 'properties':{'status':'BadRequest', 'code':400, 'type':'https://rubrics.api.brightspace.com/rels/errors/invalid-number-points-error', 'title':'InvalidNumberPointsError', 'detail':'Point value must be a valid number'}
+						}));
 					}
 				});
 				fetch.returns(promise);
 
-				var nameTextInput = element.$$('d2l-text-input');
+				var nameTextInput = element.$$('#level-name');
 				nameTextInput.value = 'Superman';
 				raf(function() {
 					element.addEventListener('d2l-siren-entity-save-error', function() {
@@ -114,7 +161,7 @@ suite('<d2l-rubric-level-editor>', function() {
 			});
 
 			test('sets aria-invalid if name is empty', function(done) {
-				var nameTextInput = element.$$('d2l-text-input');
+				var nameTextInput = element.$$('#level-name');
 				nameTextInput.value = '';
 				raf(function() {
 					flush(function() {


### PR DESCRIPTION
When saving name or points fails and the error response contains details about the error as a json payload, display the message from that payload as the bubble error message and suppress the generic "We were unable to save your rubric" error alert.
If there are no details provided, display generic error alert and use "Saving points failed"/"Saving name failed" for the bubble.