### PR TITLE
Us96776 hide level points for custom

### DIFF
--- a/editor/d2l-rubric-level-editor.html
+++ b/editor/d2l-rubric-level-editor.html
@@ -24,7 +24,7 @@
 				padding-top: 0.5rem;
 			}
 
-			.operations[noOutOf] {
+			.operations[noPoints] {
 				justify-content: flex-end;
 			}
 
@@ -57,8 +57,8 @@
 			required="[[_nameRequired]]"
 			prevent-submit>
 		</d2l-text-input>
-		<div class="operations" noOutOf$=[[!hasOutOf]]>
-			<div class="points" hidden="[[!hasOutOf]]">
+		<div class="operations" noPoints$=[[!_showPoints]]>
+			<div class="points" hidden="[[!_showPoints]]">
 				<d2l-text-input
 					id="level-points"
 					value="[[entity.properties.points]]"
@@ -126,6 +126,10 @@
 				_pointsInvalidError: {
 					type: String
 				},
+				_showPoints: {
+					type: Boolean,
+					computed: '_computeShowPoints(hasOutOf, entity)'
+				}
 			},
 
 			behaviors: [
@@ -161,6 +165,9 @@
 					return false;
 				}
 				return field.hasClass('required');
+			},
+			_computeShowPoints: function(hasOutOf, entity) {
+				return hasOutOf && entity && !entity.hasClass('overridden');
 			},
 			_saveName: function(e) {
 				var action = this.entity.getActionByName('update-name');

--- a/test/components/d2l-rubric-level-editor.html
+++ b/test/components/d2l-rubric-level-editor.html
@@ -28,6 +28,12 @@
 				</d2l-rubric-level-editor>
 			</template>
 		</test-fixture>
+		<test-fixture id="custompoints">
+			<template>
+				<d2l-rubric-level-editor href="static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json">
+				</d2l-rubric-level-editor>
+			</template>
+		</test-fixture>
 		<test-fixture id="readonly">
 			<template>
 				<d2l-rubric-level-editor

--- a/test/components/d2l-rubric-level-editor.js
+++ b/test/components/d2l-rubric-level-editor.js
@@ -126,6 +126,34 @@ suite('<d2l-rubric-level-editor>', function() {
 			});
 		});
 
+		suite('custom points', function() {
+
+			var fetch;
+			var element;
+
+			setup(function(done) {
+				element = fixture('custompoints');
+				function waitForLoad(e) {
+					if (e.detail.entity.getLinkByRel('self').href === 'static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json') {
+						element.removeEventListener('d2l-siren-entity-changed', waitForLoad);
+						done();
+					}
+				}
+				element.addEventListener('d2l-siren-entity-changed', waitForLoad);
+				element.token = 'foozleberries';
+			});
+
+			teardown(function() {
+				fetch && fetch.restore();
+				window.D2L.Siren.EntityStore.clear();
+			});
+
+			test('level points are hidden', function() {
+				var pointsInput = element.$$('.points');
+				expect(pointsInput).to.be.hidden;
+			});
+		});
+
 		suite('delete level', function() {
 			var fetch;
 			var element;

--- a/test/components/static-data/rubrics/organizations/custom-points/199.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199.json
@@ -1,0 +1,53 @@
+{
+    "class": [
+        "rubric",
+        "published",
+        "analytic",
+        "numeric"
+    ],
+    "properties": {
+        "name": "Custom Points",
+        "outOf": 12
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points.json"
+        },
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criteria-groups"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups.json"
+        },
+        {
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups-group-added.js
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups-group-added.js
@@ -1,0 +1,116 @@
+/*eslint quotes: 0 */
+window.testFixtures = window.testFixtures || {};
+
+Object.assign(window.testFixtures, {
+	get criteria_group_added() {
+		return {
+            "class": [
+                "collection",
+                "criteria-groups"
+            ],
+            "entities": [
+                {
+                    "class": [
+						"criteria-group",
+						"numeric"
+                    ],
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/criteria",
+                        "item"
+                    ],
+                    "properties": {
+						"name": "Criteria 1",
+						"outOf": 12
+                    },
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/criteria"
+                            ],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+                        },
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/levels"
+                            ],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+						"criteria-group",
+						"numeric"
+                    ],
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/criteria",
+                        "item"
+                    ],
+                    "properties": {
+						"name": "Criteria 2",
+						"outOf": 12
+                    },
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/criteria"
+                            ],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/183/criteria.json"
+                        },
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/levels"
+                            ],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/183/levels.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/183.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups.json"
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+					"href": "static-data/rubrics/organizations/custom-points/199.json"
+                }
+            ],
+            "actions": [
+                {
+					"href": "static-data/rubrics/organizations/custom-points/199/groups.json",
+                    "name": "create",
+                    "method": "POST"
+                }
+            ]
+        };
+    }
+});

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups-readonly.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups-readonly.json
@@ -1,0 +1,62 @@
+{
+    "class": [
+        "collection",
+        "criteria-groups"
+    ],
+    "entities": [
+        {
+            "class": [
+                "criteria-group",
+                "numeric"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criteria",
+                "item"
+            ],
+            "properties": {
+                "name": "Criteria",
+                "outOf": 12
+            },
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/criteria"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+                },
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/levels"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups-readonly.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups-readonly.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups.json
@@ -1,0 +1,69 @@
+{
+    "class": [
+        "collection",
+        "criteria-groups"
+    ],
+    "entities": [
+        {
+            "class": [
+                "criteria-group",
+                "numeric"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criteria",
+                "item"
+            ],
+            "properties": {
+                "name": "Criteria",
+                "outOf": 12
+            },
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/criteria"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+                },
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/levels"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199.json"
+        }
+    ],
+    "actions": [
+        {
+            "href": "static-data/rubrics/organizations/custom-points/199/groups.json",
+            "name": "create",
+            "method": "POST"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176-name-mod.js
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176-name-mod.js
@@ -1,0 +1,50 @@
+/*eslint quotes: 0 */
+window.testFixtures = window.testFixtures || {};
+
+Object.assign(window.testFixtures, {
+	get group_name_mod() {
+        return {
+            "class": [
+				"criteria-group",
+				"numeric"
+            ],
+            "properties": {
+				"name": "New Group Name",
+				"outOf": 12
+            },
+            "actions": [
+                {
+                    "name": "update",
+                    "method": "PUT",
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/criteria"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+                },
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/levels"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups.json"
+                }
+            ]
+        }
+    }
+});

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176-readonly.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176-readonly.json
@@ -1,0 +1,36 @@
+{
+    "class": [
+        "criteria-group",
+        "numeric"
+    ],
+    "properties": {
+        "name": "Criteria",
+        "outOf": 12
+    },
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criteria"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+        },
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/levels"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176-readonly.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176.json
@@ -1,0 +1,43 @@
+{
+    "class": [
+        "criteria-group",
+        "numeric"
+    ],
+    "properties": {
+        "name": "Criteria",
+        "outOf": 12
+    },
+    "actions": [
+        {
+            "name": "update",
+            "method": "PUT",
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criteria"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+        },
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/levels"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria-criterion-added.js
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria-criterion-added.js
@@ -1,0 +1,991 @@
+/*eslint quotes: 0 */
+window.testFixtures = window.testFixtures || {};
+
+Object.assign(window.testFixtures, {
+	get criterion_added() {
+		return {
+			"class": [
+				"collection",
+				"criteria"
+			],
+			"actions": [{
+				"name": "create",
+				"method": "POST",
+				"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json",
+				"fields": []
+			}],
+			"entities": [{
+				"class": [
+					"criterion",
+					"numeric"
+				],
+				"rel": [
+					"https://rubrics.api.brightspace.com/rels/criterion"
+				],
+				"properties": {
+					"name": "Criterion 1",
+					"outOf": 4
+				},
+				"entities": [{
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 4",
+						"points": 4
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "Proper use of grammar",
+							"html": "Proper use of grammar"
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+					}]
+				}, {
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 3",
+						"points": 3
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/1.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+					}]
+				}, {
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 2",
+						"points": 2
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/2.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+					}]
+				}, {
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 1",
+						"points": 1
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/3.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+					}]
+				}],
+				"links": [{
+					"rel": [
+						"self"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+				}, {
+					"rel": [
+						"up"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+				}]
+			}, {
+				"class": [
+					"criterion",
+					"numeric"
+				],
+				"rel": [
+					"https://rubrics.api.brightspace.com/rels/criterion"
+				],
+				"properties": {
+					"name": "Criterion 2",
+					"outOf": 4
+				},
+				"entities": [{
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 4",
+						"points": 4
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/0.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+					}]
+				}, {
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 3",
+						"points": 3
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/1.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+					}]
+				}, {
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 2",
+						"points": 2
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/2.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+					}]
+				}, {
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 1",
+						"points": 1
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/3.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+					}]
+				}],
+				"links": [{
+					"rel": [
+						"self"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+				}, {
+					"rel": [
+						"up"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+				}]
+			}, {
+				"class": [
+					"criterion",
+					"numeric"
+				],
+				"rel": [
+					"https://rubrics.api.brightspace.com/rels/criterion"
+				],
+				"properties": {
+					"name": "Criterion 3",
+					"outOf": 4
+				},
+				"entities": [{
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 4",
+						"points": 4
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/0.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+					}]
+				}, {
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 3",
+						"points": 3
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/1.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+					}]
+				}, {
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 2",
+						"points": 2
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/2.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+					}]
+				}, {
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 1",
+						"points": 1
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/3.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+					}]
+				}],
+				"links": [{
+					"rel": [
+						"self"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+				}, {
+					"rel": [
+						"up"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+				}]
+			}, {
+				"class": [
+					"criterion",
+					"numeric"
+				],
+				"rel": [
+					"https://rubrics.api.brightspace.com/rels/criterion"
+				],
+				"properties": {
+					"name": "New Criterion",
+					"outOf": 4
+				},
+				"entities": [{
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 4",
+						"points": 4
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "Proper use of grammar",
+							"html": "Proper use of grammar"
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/626/0.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/626.json"
+					}]
+				}, {
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 3",
+						"points": 3
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/626/1.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/626.json"
+					}]
+				}, {
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 2",
+						"points": 2
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/626/2.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/626.json"
+					}]
+				}, {
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 1",
+						"points": 1
+					},
+					"entities": [{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}, {
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "",
+							"html": ""
+						}
+					}],
+					"links": [{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+					}, {
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/626/3.json"
+					}, {
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/626.json"
+					}]
+				}],
+				"links": [{
+					"rel": [
+						"self"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/626.json"
+				}, {
+					"rel": [
+						"up"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+				}]
+			}],
+			"links": [{
+				"rel": [
+					"self"
+				],
+				"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+			}, {
+				"rel": [
+					"up"
+				],
+				"href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+			}]
+		};
+	}
+});

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria-readonly.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria-readonly.json
@@ -1,0 +1,853 @@
+{
+    "class": [
+        "collection",
+        "criteria"
+    ],
+    "entities": [
+        {
+            "class": [
+                "criterion",
+                "numeric"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criterion"
+            ],
+            "properties": {
+                "name": "Criterion 1",
+                "outOf": 4
+            },
+            "entities": [
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 4",
+                      "points": 4
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "Proper use of grammar",
+                                "html": "Proper use of grammar"
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 3",
+                      "points": 3
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/1.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 2",
+                      "points": 2
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/2.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 1",
+                      "points": 1
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/3.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion",
+                "numeric"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criterion"
+            ],
+            "properties": {
+                "name": "Criterion 2",
+                "outOf": 4
+            },
+            "entities": [
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 4",
+                      "points": 4
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/0.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 3",
+                      "points": 3
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/1.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 2",
+                      "points": 2
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/2.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 1",
+                      "points": 1
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/3.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion",
+                "numeric"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criterion"
+            ],
+            "properties": {
+                "name": "Criterion 3",
+                "outOf": 4
+            },
+            "entities": [
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 4",
+                      "points": 4
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/0.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 3",
+                      "points": 3
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/1.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 2",
+                      "points": 2
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/2.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 1",
+                      "points": 1
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/3.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria-readonly.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json
@@ -1,0 +1,871 @@
+{
+    "class": [
+        "collection",
+        "criteria"
+    ],
+    "actions": [{
+      "name": "create",
+      "method": "POST",
+      "href":  "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json",
+      "fields": []
+    }, {
+      "name": "reorder",
+      "method": "POST",
+      "href":  "static-data/rubrics/organizations/custom-points/199/groups/176/criteria-reorder",
+      "fields": [{
+          "name": "newIndex",
+          "type": "number"
+        }, {
+            "name": "oldIndex",
+            "type": "number"
+          }
+        ]
+    }],
+    "entities": [
+        {
+            "class": [
+                "criterion",
+                "numeric"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criterion"
+            ],
+            "properties": {
+                "name": "Criterion 1",
+                "outOf": 4
+            },
+            "entities": [
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 4",
+                      "points": 4
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "Proper use of grammar",
+                                "html": "Proper use of grammar"
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 3",
+                      "points": 3
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/1.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 2",
+                      "points": 2
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/2.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 1",
+                      "points": 1
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/3.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion",
+                "numeric"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criterion"
+            ],
+            "properties": {
+                "name": "Criterion 2",
+                "outOf": 4
+            },
+            "entities": [
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 4",
+                      "points": 4
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/0.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 3",
+                      "points": 3
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/1.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 2",
+                      "points": 2
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/2.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 1",
+                      "points": 1
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/3.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion",
+                "numeric"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/criterion"
+            ],
+            "properties": {
+                "name": "Criterion 3",
+                "outOf": 4
+            },
+            "entities": [
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 4",
+                      "points": 4
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/0.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 3",
+                      "points": 3
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/1.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 2",
+                      "points": 2
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/2.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "criterion-cell",
+                        "overridden"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://rubrics.api.brightspace.com/rels/criterion-cell"
+                    ],
+                    "properties": {
+                      "levelName": "Level 1",
+                      "points": 1
+                    },
+                    "entities": [
+                        {
+                            "class": [
+                                "richtext",
+                                "description"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        },
+                        {
+                            "class": [
+                                "richtext",
+                                "feedback"
+                            ],
+                            "rel": [
+                                "item"
+                            ],
+                            "properties": {
+                                "text": "",
+                                "html": ""
+                            }
+                        }
+                    ],
+                    "links": [
+                        {
+                            "rel": [
+                                "https://rubrics.api.brightspace.com/rels/level"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+                        },
+                        {
+                            "rel": [
+                                "self"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/3.json"
+                        },
+                        {
+                            "rel": [
+                                "up"
+                            ],
+                            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623-name-mod.js
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623-name-mod.js
@@ -1,0 +1,103 @@
+/*eslint quotes: 0 */
+window.testFixtures = window.testFixtures || {};
+
+Object.assign(window.testFixtures, {
+	get criterion_name_mod() {
+		return {
+			"class": [
+				"criterion",
+				"numeric"
+			],
+			"properties": {
+				"name": "Batman and Robin",
+				"outOf": 4
+			},
+			"actions": [{
+				"name": "update",
+				"method": "PUT",
+				"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json",
+				"fields": [{
+					"type": "text",
+					"name": "name",
+					"value": "Batman and Robin"
+				}]
+			}],
+			"entities": [
+				{
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 4",
+						"points": 4
+					},
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json"
+				},
+				{
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 3",
+						"points": 3
+					},
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/1.json"
+				},
+				{
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 2",
+						"points": 2
+					},
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/2.json"
+				},
+				{
+					"class": [
+						"criterion-cell",
+						"overridden"
+					],
+					"rel": [
+						"item",
+						"https://rubrics.api.brightspace.com/rels/criterion-cell"
+					],
+					"properties": {
+						"levelName": "Level 1",
+						"points": 1
+					},
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/3.json"
+				}
+			],
+			"links": [
+				{
+					"rel": [
+						"self"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+				},
+				{
+					"rel": [
+						"up"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+				}
+			]
+		};
+	}
+});

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json
@@ -1,0 +1,404 @@
+{
+    "class": [
+        "criterion",
+        "numeric"
+    ],
+    "properties": {
+        "name": "Criterion 1",
+        "outOf": 4
+    },
+    "actions": [{
+      "name": "update",
+      "method": "PUT",
+      "href":  "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json",
+      "fields": [{
+        "class": ["required"],
+        "type": "text",
+        "name": "name",
+        "value": "Criterion 1"
+      }]
+    },
+    {
+        "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json",
+        "name": "delete",
+        "method": "DELETE"
+    }],
+    "entities": [
+        {
+            "class": [
+                "criterion-cell",
+                "overridden"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "properties": {
+              "levelName": "Level 4",
+              "points": 4
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "Proper use of grammar",
+                        "html": "Proper use of grammar"
+                    },
+                    "actions": [
+                      {
+                        "name": "update",
+                        "method": "PUT",
+                        "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json",
+                        "fields": [
+                          {
+                            "type": "text",
+                            "name": "description",
+                            "value": "Proper use of grammar"
+                          },
+                          {
+                            "type": "hidden",
+                            "name": "feedback",
+                            "value": "5 stars for proper use of grammar!"
+                          }
+                        ]
+                      }
+                    ]
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "5 stars for proper use of grammar!",
+                        "html": "5 stars for proper use of grammar!"
+                    },
+                    "actions": [
+                      {
+                        "name": "update",
+                        "method": "PUT",
+                        "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json",
+                        "fields": [
+                          {
+                            "type": "hidden",
+                            "name": "description",
+                            "value": "Proper use of grammar"
+                          },
+                          {
+                            "type": "text",
+                            "name": "feedback",
+                            "value": "5 stars for proper use of grammar!"
+                          }
+                        ]
+                      }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell",
+                "overridden"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "properties": {
+              "levelName": "Level 3",
+              "points": 3
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/1.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell",
+                "overridden"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "properties": {
+              "levelName": "Level 2",
+              "points": 2
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    },
+                    "actions": [
+                      {
+                        "name": "update",
+                        "method": "PUT",
+                        "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/2.json",
+                        "fields": [
+                          {
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                          },
+                          {
+                            "type": "hidden",
+                            "name": "feedback",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    ]
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    },
+                    "actions": [
+                      {
+                        "name": "update",
+                        "method": "PUT",
+                        "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/2.json",
+                        "fields": [
+                          {
+                            "type": "hidden",
+                            "name": "description",
+                            "value": ""
+                          },
+                          {
+                            "type": "text",
+                            "name": "feedback",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/2.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell",
+                "overridden"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "properties": {
+              "levelName": "Level 1",
+              "points": 1
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    },
+                    "actions": [
+                      {
+                        "name": "update",
+                        "method": "PUT",
+                        "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/3.json",
+                        "fields": [
+                          {
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                          },
+                          {
+                            "type": "hidden",
+                            "name": "feedback",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    ]
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    },
+                    "actions": [
+                      {
+                        "name": "update",
+                        "method": "PUT",
+                        "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/3.json",
+                        "fields": [
+                          {
+                            "type": "hidden",
+                            "name": "description",
+                            "value": ""
+                          },
+                          {
+                            "type": "text",
+                            "name": "feedback",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/3.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0-description-mod.js
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0-description-mod.js
@@ -1,0 +1,104 @@
+/*eslint quotes: 0 */
+window.testFixtures = window.testFixtures || {};
+
+Object.assign(window.testFixtures,
+	{
+		get criterion_cell_description_mod() {
+			return {
+				"class": [
+					"criterion-cell",
+					"overridden"
+				],
+				"properties": {
+					"levelName": "Level 4",
+					"points": 4
+				},
+				"entities": [
+					{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "Proper use of grammar",
+							"html": "Proper use of grammar"
+						},
+						"actions": [
+							{
+								"name": "update",
+								"method": "PUT",
+								"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json",
+								"fields": [
+									{
+										"type": "text",
+										"name": "description",
+										"value": "Proper use of grammar"
+									},
+									{
+										"type": "hidden",
+										"name": "feedback",
+										"value": "5 stars for proper use of grammar!"
+									}
+								]
+							}
+						]
+					},
+					{
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "5 stars for proper use of grammar!",
+							"html": "5 stars for proper use of grammar!"
+						},
+						"actions": [
+							{
+								"name": "update",
+								"method": "PUT",
+								"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json",
+								"fields": [
+									{
+										"type": "hidden",
+										"name": "description",
+										"value": "Proper use of grammar"
+									},
+									{
+										"type": "text",
+										"name": "feedback",
+										"value": "5 stars for proper use of grammar!"
+									}
+								]
+							}
+						]
+					}
+				],
+				"links": [
+					{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+					},
+					{
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json"
+					},
+					{
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+					}
+				]
+			};
+		}
+	});

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0-feedback-mod.js
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0-feedback-mod.js
@@ -1,0 +1,104 @@
+/*eslint quotes: 0 */
+window.testFixtures = window.testFixtures || {};
+
+Object.assign(window.testFixtures,
+	{
+		get criterion_cell_feedback_mod() {
+			return {
+				"class": [
+					"criterion-cell",
+					"overridden"
+				],
+				"properties": {
+					"levelName": "Level 4",
+					"points": 4
+				},
+				"entities": [
+					{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "Proper use of grammar",
+							"html": "Proper use of grammar"
+						},
+						"actions": [
+							{
+								"name": "update",
+								"method": "PUT",
+								"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json",
+								"fields": [
+									{
+										"type": "text",
+										"name": "description",
+										"value": "Proper use of grammar"
+									},
+									{
+										"type": "hidden",
+										"name": "feedback",
+										"value": "5 stars for proper use of grammar!"
+									}
+								]
+							}
+						]
+					},
+					{
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "You are a grammar rockstar!",
+							"html": "You are a grammar rockstar!"
+						},
+						"actions": [
+							{
+								"name": "update",
+								"method": "PUT",
+								"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json",
+								"fields": [
+									{
+										"type": "hidden",
+										"name": "description",
+										"value": "Proper use of grammar"
+									},
+									{
+										"type": "text",
+										"name": "feedback",
+										"value": "You are a grammar rockstar!"
+									}
+								]
+							}
+						]
+					}
+				],
+				"links": [
+					{
+						"rel": [
+							"https://rubrics.api.brightspace.com/rels/level"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+					},
+					{
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json"
+					},
+					{
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+					}
+				]
+			};
+		}
+	});

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json
@@ -1,0 +1,96 @@
+{
+    "class": [
+        "criterion-cell",
+        "overridden"
+    ],
+    "properties": {
+      "levelName": "Level 4",
+      "points": 4
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "Proper use of grammar",
+                "html": "Proper use of grammar"
+            },
+            "actions": [
+              {
+                "name": "update",
+                "method": "PUT",
+                "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json",
+                "fields": [
+                  {
+                    "type": "text",
+                    "name": "description",
+                    "value": "Proper use of grammar"
+                  },
+                  {
+                    "type": "hidden",
+                    "name": "feedback",
+                    "value": "5 stars for proper use of grammar!"
+                  }
+                ]
+              }
+            ]
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "5 stars for proper use of grammar!",
+                "html": "5 stars for proper use of grammar!"
+            },
+            "actions": [
+              {
+                "name": "update",
+                "method": "PUT",
+                "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json",
+                "fields": [
+                  {
+                    "type": "hidden",
+                    "name": "description",
+                    "value": "Proper use of grammar"
+                  },
+                  {
+                    "type": "text",
+                    "name": "feedback",
+                    "value": "5 stars for proper use of grammar!"
+                  }
+                ]
+              }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/0.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/1.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/1.json
@@ -1,0 +1,58 @@
+{
+    "class": [
+        "criterion-cell",
+        "overridden"
+    ],
+    "properties": {
+      "levelName": "Level 3",
+      "points": 3
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/1.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/2.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/2.json
@@ -1,0 +1,96 @@
+{
+    "class": [
+        "criterion-cell",
+        "overridden"
+    ],
+    "properties": {
+      "levelName": "Level 2",
+      "points": 2
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            },
+            "actions": [
+              {
+                "name": "update",
+                "method": "PUT",
+                "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/2.json",
+                "fields": [
+                  {
+                    "type": "text",
+                    "name": "description",
+                    "value": ""
+                  },
+                  {
+                    "type": "hidden",
+                    "name": "feedback",
+                    "value": ""
+                  }
+                ]
+              }
+            ]
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            },
+            "actions": [
+              {
+                "name": "update",
+                "method": "PUT",
+                "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/2.json",
+                "fields": [
+                  {
+                    "type": "hidden",
+                    "name": "description",
+                    "value": ""
+                  },
+                  {
+                    "type": "text",
+                    "name": "feedback",
+                    "value": ""
+                  }
+                ]
+              }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/2.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/3.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/3.json
@@ -1,0 +1,96 @@
+{
+    "class": [
+        "criterion-cell",
+        "overridden"
+    ],
+    "properties": {
+      "levelName": "Level 1",
+      "points": 1
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            },
+            "actions": [
+              {
+                "name": "update",
+                "method": "PUT",
+                "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/3.json",
+                "fields": [
+                  {
+                    "type": "text",
+                    "name": "description",
+                    "value": ""
+                  },
+                  {
+                    "type": "hidden",
+                    "name": "feedback",
+                    "value": ""
+                  }
+                ]
+              }
+            ]
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            },
+            "actions": [
+              {
+                "name": "update",
+                "method": "PUT",
+                "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/3.json",
+                "fields": [
+                  {
+                    "type": "hidden",
+                    "name": "description",
+                    "value": ""
+                  },
+                  {
+                    "type": "text",
+                    "name": "feedback",
+                    "value": ""
+                  }
+                ]
+              }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623/3.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/623.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json
@@ -1,0 +1,274 @@
+{
+    "class": [
+        "criterion",
+        "numeric"
+    ],
+    "properties": {
+        "name": "Criterion 2",
+        "outOf": 4
+    },
+    "entities": [
+        {
+            "class": [
+                "criterion-cell",
+                "overridden"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "properties": {
+              "levelName": "Level 4",
+              "points": 4
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/0.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell",
+                "overridden"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "properties": {
+              "levelName": "Level 3",
+              "points": 3
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/1.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell",
+                "overridden"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "properties": {
+              "levelName": "Level 2",
+              "points": 2
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/2.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell",
+                "overridden"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "properties": {
+              "levelName": "Level 1",
+              "points": 1
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/3.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/0.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/0.json
@@ -1,0 +1,58 @@
+{
+    "class": [
+        "criterion-cell",
+        "overridden"
+    ],
+    "properties": {
+      "levelName": "Level 4",
+      "points": 4
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/0.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/1.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/1.json
@@ -1,0 +1,58 @@
+{
+    "class": [
+        "criterion-cell",
+        "overridden"
+    ],
+    "properties": {
+      "levelName": "Level 3",
+      "points": 3
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/1.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/2.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/2.json
@@ -1,0 +1,58 @@
+{
+    "class": [
+        "criterion-cell",
+        "overridden"
+    ],
+    "properties": {
+      "levelName": "Level 2",
+      "points": 2
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/2.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/3.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/3.json
@@ -1,0 +1,58 @@
+{
+    "class": [
+        "criterion-cell",
+        "overridden"
+    ],
+    "properties": {
+      "levelName": "Level 1",
+      "points": 1
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624/3.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/624.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json
@@ -1,0 +1,274 @@
+{
+    "class": [
+        "criterion",
+        "numeric"
+    ],
+    "properties": {
+        "name": "Criterion 3",
+        "outOf": 4
+    },
+    "entities": [
+        {
+            "class": [
+                "criterion-cell",
+                "overridden"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "properties": {
+              "levelName": "Level 4",
+              "points": 4
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/0.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell",
+                "overridden"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "properties": {
+              "levelName": "Level 3",
+              "points": 3
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/1.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell",
+                "overridden"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "properties": {
+              "levelName": "Level 2",
+              "points": 2
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/2.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "criterion-cell",
+                "overridden"
+            ],
+            "rel": [
+                "item",
+                "https://rubrics.api.brightspace.com/rels/criterion-cell"
+            ],
+            "properties": {
+              "levelName": "Level 1",
+              "points": 1
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": ""
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://rubrics.api.brightspace.com/rels/level"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/3.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/0.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/0.json
@@ -1,0 +1,58 @@
+{
+    "class": [
+        "criterion-cell",
+        "overridden"
+    ],
+    "properties": {
+      "levelName": "Level 4",
+      "points": 4
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/0.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/1.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/1.json
@@ -1,0 +1,58 @@
+{
+    "class": [
+        "criterion-cell",
+        "overridden"
+    ],
+    "properties": {
+      "levelName": "Level 3",
+      "points": 3
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/1.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/2.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/2.json
@@ -1,0 +1,58 @@
+{
+    "class": [
+        "criterion-cell",
+        "overridden"
+    ],
+    "properties": {
+      "levelName": "Level 2",
+      "points": 2
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/2.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/3.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/3.json
@@ -1,0 +1,58 @@
+{
+    "class": [
+        "criterion-cell",
+        "overridden"
+    ],
+    "properties": {
+      "levelName": "Level 1",
+      "points": 1
+    },
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "",
+                "html": ""
+            }
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625/3.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/criteria/625.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels-level-appended.js
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels-level-appended.js
@@ -1,0 +1,236 @@
+/*eslint quotes: 0 */
+window.testFixtures = window.testFixtures || {};
+
+Object.assign(window.testFixtures, {
+	get level_appended() {
+		return {
+			"class": [
+				"collection",
+				"levels"
+			],
+			"actions": [
+				{
+					"name": "append",
+					"method": "POST",
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json",
+					"fields": [
+						{
+							"type": "hidden",
+							"name": "relativePosition",
+							"value": "Append"
+						}
+					]
+				},
+				{
+					"name": "prepend",
+					"method": "POST",
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json",
+					"fields": [
+						{
+							"type": "hidden",
+							"name": "relativePosition",
+							"value": "Prepend"
+						}
+					]
+				}
+			],
+			"properties": {
+				"total": 5
+			},
+			"entities": [
+				{
+					"class": [
+						"level",
+						"overridden"
+					],
+					"rel": [
+						"https://rubrics.api.brightspace.com/rels/level"
+					],
+					"properties": {
+						"name": "Level 4"
+					},
+					"links": [
+						{
+							"rel": [
+								"self"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+						},
+						{
+							"rel": [
+								"up"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+						},
+						{
+							"rel": [
+								"next"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+						}
+					]
+				},
+				{
+					"class": [
+						"level",
+						"overridden"
+					],
+					"rel": [
+						"https://rubrics.api.brightspace.com/rels/level"
+					],
+					"properties": {
+						"name": "Level 3"
+					},
+					"links": [
+						{
+							"rel": [
+								"self"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+						},
+						{
+							"rel": [
+								"up"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+						},
+						{
+							"rel": [
+								"prev"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+						},
+						{
+							"rel": [
+								"next"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+						}
+					]
+				},
+				{
+					"class": [
+						"level",
+						"overridden"
+					],
+					"rel": [
+						"https://rubrics.api.brightspace.com/rels/level"
+					],
+					"properties": {
+						"name": "Level 2"
+					},
+					"links": [
+						{
+							"rel": [
+								"self"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+						},
+						{
+							"rel": [
+								"up"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+						},
+						{
+							"rel": [
+								"prev"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+						},
+						{
+							"rel": [
+								"next"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+						}
+					]
+				},
+				{
+					"class": [
+						"level",
+						"overridden"
+					],
+					"rel": [
+						"https://rubrics.api.brightspace.com/rels/level"
+					],
+					"properties": {
+						"name": "Level 1"
+					},
+					"links": [
+						{
+							"rel": [
+								"self"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+						},
+						{
+							"rel": [
+								"up"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+						},
+						{
+							"rel": [
+								"prev"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+						},
+						{
+							"rel": [
+								"next"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1480.json"
+						}
+					]
+				},
+				{
+					"class": [
+						"level",
+						"overridden"
+					],
+					"rel": [
+						"https://rubrics.api.brightspace.com/rels/level"
+					],
+					"properties": {
+						"name": "New Level"
+					},
+					"links": [
+						{
+							"rel": [
+								"self"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1480.json"
+						},
+						{
+							"rel": [
+								"up"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+						},
+						{
+							"rel": [
+								"prev"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+						}
+					]
+				},
+			],
+			"links": [
+				{
+					"rel": [
+						"self"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+				},
+				{
+					"rel": [
+						"up"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+				}
+			]
+		};
+	}
+});

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels-level-prepended.js
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels-level-prepended.js
@@ -1,0 +1,236 @@
+/*eslint quotes: 0 */
+window.testFixtures = window.testFixtures || {};
+
+Object.assign(window.testFixtures, {
+	get level_prepended() {
+		return {
+			"class": [
+				"collection",
+				"levels"
+			],
+			"actions": [
+				{
+					"name": "append",
+					"method": "POST",
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json",
+					"fields": [
+						{
+							"type": "hidden",
+							"name": "relativePosition",
+							"value": "Append"
+						}
+					]
+				},
+				{
+					"name": "prepend",
+					"method": "POST",
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json",
+					"fields": [
+						{
+							"type": "hidden",
+							"name": "relativePosition",
+							"value": "Prepend"
+						}
+					]
+				}
+			],
+			"properties": {
+				"total": 5
+			},
+			"entities": [
+				{
+					"class": [
+						"level",
+						"overridden"
+					],
+					"rel": [
+						"https://rubrics.api.brightspace.com/rels/level"
+					],
+					"properties": {
+						"name": "New Level"
+					},
+					"links": [
+						{
+							"rel": [
+								"self"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1475.json"
+						},
+						{
+							"rel": [
+								"up"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+						},
+						{
+							"rel": [
+								"next"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+						}
+					]
+				},
+				{
+					"class": [
+						"level",
+						"overridden"
+					],
+					"rel": [
+						"https://rubrics.api.brightspace.com/rels/level"
+					],
+					"properties": {
+						"name": "Level 4"
+					},
+					"links": [
+						{
+							"rel": [
+								"self"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+						},
+						{
+							"rel": [
+								"up"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+						},
+						{
+							"rel": [
+								"prev"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1475.json"
+						},
+						{
+							"rel": [
+								"next"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+						}
+					]
+				},
+				{
+					"class": [
+						"level",
+						"overridden"
+					],
+					"rel": [
+						"https://rubrics.api.brightspace.com/rels/level"
+					],
+					"properties": {
+						"name": "Level 3"
+					},
+					"links": [
+						{
+							"rel": [
+								"self"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+						},
+						{
+							"rel": [
+								"up"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+						},
+						{
+							"rel": [
+								"prev"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+						},
+						{
+							"rel": [
+								"next"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+						}
+					]
+				},
+				{
+					"class": [
+						"level",
+						"overridden"
+					],
+					"rel": [
+						"https://rubrics.api.brightspace.com/rels/level"
+					],
+					"properties": {
+						"name": "Level 2"
+					},
+					"links": [
+						{
+							"rel": [
+								"self"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+						},
+						{
+							"rel": [
+								"up"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+						},
+						{
+							"rel": [
+								"prev"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+						},
+						{
+							"rel": [
+								"next"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+						}
+					]
+				},
+				{
+					"class": [
+						"level",
+						"overridden"
+					],
+					"rel": [
+						"https://rubrics.api.brightspace.com/rels/level"
+					],
+					"properties": {
+						"name": "Level 1"
+					},
+					"links": [
+						{
+							"rel": [
+								"self"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+						},
+						{
+							"rel": [
+								"up"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+						},
+						{
+							"rel": [
+								"prev"
+							],
+							"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+						}
+					]
+				}
+			],
+			"links": [
+				{
+					"rel": [
+						"self"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+				},
+				{
+					"rel": [
+						"up"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+				}
+			]
+		};
+	}
+});

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels-readonly.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels-readonly.json
@@ -1,0 +1,165 @@
+{
+    "class": [
+        "collection",
+        "levels"
+    ],
+    "properties": {
+        "total": 4
+    },
+    "entities": [
+        {
+            "class": [
+                "level",
+                "overridden"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "properties": {
+                "name": "Level 4"
+            },
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "next"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "level",
+                "overridden"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "properties": {
+                "name": "Level 3"
+            },
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "prev"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+                },
+                {
+                    "rel": [
+                        "next"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "level",
+                "overridden"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "properties": {
+                "name": "Level 2"
+            },
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "prev"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                },
+                {
+                    "rel": [
+                        "next"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "level",
+                "overridden"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "properties": {
+                "name": "Level 1"
+            },
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "prev"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels-readonly.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels.json
@@ -1,0 +1,191 @@
+{
+    "class": [
+        "collection",
+        "levels"
+    ],
+    "actions": [
+      {
+        "name": "append",
+        "method": "POST",
+        "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json",
+        "fields": [
+          {
+            "type": "hidden",
+            "name": "relativePosition",
+            "value": "Append"
+          }
+        ]
+      },
+      {
+        "name": "prepend",
+        "method": "POST",
+        "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json",
+        "fields": [
+          {
+            "type": "hidden",
+            "name": "relativePosition",
+            "value": "Prepend"
+          }
+        ]
+      }
+    ],
+    "properties": {
+        "total": 4
+    },
+    "entities": [
+        {
+            "class": [
+                "level",
+                "overridden"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "properties": {
+                "name": "Level 4"
+            },
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "next"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "level",
+                "overridden"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "properties": {
+                "name": "Level 3"
+            },
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "prev"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+                },
+                {
+                    "rel": [
+                        "next"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "level",
+                "overridden"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "properties": {
+                "name": "Level 2"
+            },
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "prev"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+                },
+                {
+                    "rel": [
+                        "next"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "level",
+                "overridden"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "properties": {
+                "name": "Level 1"
+            },
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+                },
+                {
+                    "rel": [
+                        "prev"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1475.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1475.json
@@ -1,0 +1,40 @@
+{
+    "class": [
+        "level",
+        "overridden"
+    ],
+    "properties": {
+        "name": "New Level"
+    },
+    "actions": [{
+        "name": "update",
+        "method": "PUT",
+        "href":  "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1475.json",
+        "fields": [{
+            "class": ["required"],
+            "type": "text",
+            "name": "name",
+            "value": "New Level"
+        }]
+      }],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1475.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "next"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json
@@ -1,0 +1,29 @@
+{
+    "class": [
+        "level",
+        "overridden"
+    ],
+    "properties": {
+        "name": "Level 4"
+    },
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1476.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "next"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json
@@ -1,0 +1,35 @@
+{
+    "class": [
+        "level",
+        "overridden"
+    ],
+    "properties": {
+        "name": "Level 3"
+    },
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "prev"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+        },
+        {
+            "rel": [
+                "next"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json
@@ -1,0 +1,35 @@
+{
+    "class": [
+        "level",
+        "overridden"
+    ],
+    "properties": {
+        "name": "Level 2"
+    },
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "prev"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+        },
+        {
+            "rel": [
+                "next"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479-name-mod.js
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479-name-mod.js
@@ -1,0 +1,58 @@
+/*eslint quotes: 0 */
+window.testFixtures = window.testFixtures || {};
+
+Object.assign(window.testFixtures, {
+	get level_name_mod() {
+		return {
+			"class": [
+				"level",
+				"overridden"
+			],
+			"rel": [
+				"https://rubrics.api.brightspace.com/rels/level"
+			],
+			"properties": {
+				"name": "Superman"
+			},
+			"actions": [
+				{
+					"name": "update-name",
+					"method": "PATCH",
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json",
+					"fields": [{
+						"class": ["required"],
+						"type": "text",
+						"name": "name",
+						"value": "Superman"
+					}]
+				},
+			],
+			"links": [
+				{
+					"rel": [
+						"self"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+				},
+				{
+					"rel": [
+						"up"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+				},
+				{
+					"rel": [
+						"prev"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+				},
+				{
+					"rel": [
+						"next"
+					],
+					"href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+				}
+			]
+		};
+	}
+});

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json
@@ -1,0 +1,57 @@
+{
+  "class": [
+    "level",
+    "overridden"
+  ],
+  "properties": {
+    "name": "Level 1"
+  },
+  "actions": [
+    {
+      "name": "update-name",
+      "method": "PATCH",
+      "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json",
+      "fields": [
+        {
+          "class": [
+            "required"
+          ],
+          "type": "text",
+          "name": "name",
+          "value": "Level 1"
+        }
+      ]
+    },
+    {
+      "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json",
+      "name": "delete",
+      "method": "DELETE"
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+    },
+    {
+      "rel": [
+        "up"
+      ],
+      "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+    },
+    {
+      "rel": [
+        "prev"
+      ],
+      "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1477.json"
+    },
+    {
+      "rel": [
+        "next"
+      ],
+      "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1478.json"
+    }
+  ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1480.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/groups/176/levels/1480.json
@@ -1,0 +1,40 @@
+{
+    "class": [
+        "level",
+        "overridden"
+    ],
+    "properties": {
+        "name": "New Level"
+    },
+    "actions": [{
+        "name": "update",
+        "method": "PUT",
+        "href":  "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1480.json",
+        "fields": [{
+            "class": ["required"],
+            "type": "text",
+            "name": "name",
+            "value": "New Level"
+        }]
+      }],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1480.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels.json"
+        },
+        {
+            "rel": [
+                "prev"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/groups/176/levels/1479.json"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/overall-levels.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/overall-levels.json
@@ -1,0 +1,257 @@
+{
+    "class": [
+        "collection",
+        "overall-levels"
+    ],
+    "properties": {
+        "total": 2
+    },
+    "entities": [
+        {
+            "class": [
+                "overall-level"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/overall-level"
+            ],
+            "properties": {
+                "name": "Level 2",
+                "rangeStart": 3
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "Proper use of grammar",
+                        "html": "Proper use of grammar"
+                    },
+                    "actions": [
+                        {
+                            "href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+                            "name": "update",
+                            "method": "PUT",
+                            "fields": [
+                                {
+                                    "class": [
+                                        "required"
+                                    ],
+                                    "type": "hidden",
+                                    "name": "name",
+                                    "value": "Level 2"
+                                },
+                                {
+                                    "type": "text",
+                                    "name": "description",
+                                    "value": "Proper use of grammar"
+                                },
+                                {
+                                    "type": "hidden",
+                                    "name": "feedback",
+                                    "value": "5 stars for proper use of grammar!"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "5 stars for proper use of grammar!",
+                        "html": "5 stars for proper use of grammar!"
+                    },
+                    "actions": [
+                        {
+                            "href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+                            "name": "update",
+                            "method": "PUT",
+                            "fields": [
+                                {
+                                    "class": [
+                                        "required"
+                                    ],
+                                    "type": "hidden",
+                                    "name": "name",
+                                    "value": "Level 2"
+                                },
+                                {
+                                    "type": "hidden",
+                                    "name": "description",
+                                    "value": "Proper use of grammar"
+                                },
+                                {
+                                    "type": "text",
+                                    "name": "feedback",
+                                    "value": "5 stars for proper use of grammar!"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/overall-levels/overall-levels.json"
+                },
+                {
+                    "rel": [
+                        "next"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/overall-levels/2.json"
+                }
+            ],
+            "actions": [
+                {
+                    "href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+                    "name": "update",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Level 2"
+                        },
+                        {
+                            "type": "hidden",
+                            "name": "description",
+                            "value": "Proper use of grammar"
+                        },
+                        {
+                            "type": "hidden",
+                            "name": "feedback",
+                            "value": "5 stars for proper use of grammar!"
+                        }
+                    ]
+                },
+                {
+                    "href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+                    "name": "delete",
+                    "method": "DELETE"
+                }
+            ]
+        },
+        {
+            "class": [
+                "overall-level"
+            ],
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/overall-level"
+            ],
+            "properties": {
+                "name": "Level 1",
+                "rangeStart": 0
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "Proper use of grammar",
+                        "html": "Proper use of grammar"
+                    }
+                },
+                {
+                    "class": [
+                        "richtext",
+                        "feedback"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "5 stars for proper use of grammar!",
+                        "html": "5 stars for proper use of grammar!"
+                    }
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/overall-levels/2.json"
+                },
+                {
+                    "rel": [
+                        "up"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/overall-levels/overall-levels.json"
+                },
+                {
+                    "rel": [
+                        "prev"
+                    ],
+                    "href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199/overall-levels.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/custom-points/199.json"
+        }
+    ],
+    "actions": [
+        {
+            "href": "static-data/rubrics/organizations/custom-points/199/overall-levels",
+            "name": "append",
+            "method": "POST",
+            "fields": [
+                {
+                    "type": "hidden",
+                    "name": "relativePosition",
+                    "value": "Append"
+                }
+            ]
+        },
+        {
+            "href": "static-data/rubrics/organizations/custom-points/199/overall-levels",
+            "name": "prepend",
+            "method": "POST",
+            "fields": [
+                {
+                    "type": "hidden",
+                    "name": "relativePosition",
+                    "value": "Prepend"
+                }
+            ]
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/overall-levels/1-description-mod.js
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/overall-levels/1-description-mod.js
@@ -1,0 +1,154 @@
+/*eslint quotes: 0 */
+window.testFixtures = window.testFixtures || {};
+
+Object.assign(window.testFixtures,
+	{
+		get overall_level_description_mod() {
+			return {
+				"class": [
+					"overall-level"
+				],
+				"rel": [
+					"https://rubrics.api.brightspace.com/rels/overall-level"
+				],
+				"properties": {
+					"name": "Level 2",
+					"rangeStart": 3
+				},
+				"entities": [
+					{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "Batman and Robin",
+							"html": "Batman and Robin"
+						},
+						"actions": [
+							{
+								"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+								"name": "update",
+								"method": "PUT",
+								"fields": [
+									{
+										"class": [
+											"required"
+										],
+										"type": "hidden",
+										"name": "name",
+										"value": "Level 2"
+									},
+									{
+										"type": "text",
+										"name": "description",
+										"value": "Batman and Robin"
+									},
+									{
+										"type": "hidden",
+										"name": "feedback",
+										"value": "5 stars for proper use of grammar!"
+									}
+								]
+							}
+						]
+					},
+					{
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "5 stars for proper use of grammar!",
+							"html": "5 stars for proper use of grammar!"
+						},
+						"actions": [
+							{
+								"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+								"name": "update",
+								"method": "PUT",
+								"fields": [
+									{
+										"class": [
+											"required"
+										],
+										"type": "hidden",
+										"name": "name",
+										"value": "Level 2"
+									},
+									{
+										"type": "hidden",
+										"name": "description",
+										"value": "Batman and Robin"
+									},
+									{
+										"type": "text",
+										"name": "feedback",
+										"value": "5 stars for proper use of grammar!"
+									}
+								]
+							}
+						]
+					}
+				],
+				"links": [
+					{
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json"
+					},
+					{
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/overall-levels.json"
+					},
+					{
+						"rel": [
+							"next"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/2"
+					}
+				],
+				"actions": [
+					{
+						"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+						"name": "update",
+						"method": "PUT",
+						"fields": [
+							{
+								"class": [
+									"required"
+								],
+								"type": "text",
+								"name": "name",
+								"value": "Level 2"
+							},
+							{
+								"type": "hidden",
+								"name": "description",
+								"value": "Batman and Robin"
+							},
+							{
+								"type": "hidden",
+								"name": "feedback",
+								"value": "5 stars for proper use of grammar!"
+							}
+						]
+					},
+					{
+						"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+						"name": "delete",
+						"method": "DELETE"
+					}
+				]
+			};
+		}
+	});

--- a/test/components/static-data/rubrics/organizations/custom-points/199/overall-levels/1-feedback-mod.js
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/overall-levels/1-feedback-mod.js
@@ -1,0 +1,154 @@
+/*eslint quotes: 0 */
+window.testFixtures = window.testFixtures || {};
+
+Object.assign(window.testFixtures,
+	{
+		get overall_level_feedback_mod() {
+			return {
+				"class": [
+					"overall-level"
+				],
+				"rel": [
+					"https://rubrics.api.brightspace.com/rels/overall-level"
+				],
+				"properties": {
+					"name": "Level 2",
+					"rangeStart": 3
+				},
+				"entities": [
+					{
+						"class": [
+							"richtext",
+							"description"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "Proper use of grammar",
+							"html": "Proper use of grammar"
+						},
+						"actions": [
+							{
+								"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+								"name": "update",
+								"method": "PUT",
+								"fields": [
+									{
+										"class": [
+											"required"
+										],
+										"type": "hidden",
+										"name": "name",
+										"value": "Level 2"
+									},
+									{
+										"type": "text",
+										"name": "description",
+										"value": "Proper use of grammar"
+									},
+									{
+										"type": "hidden",
+										"name": "feedback",
+										"value": "You are a grammar rockstar!"
+									}
+								]
+							}
+						]
+					},
+					{
+						"class": [
+							"richtext",
+							"feedback"
+						],
+						"rel": [
+							"item"
+						],
+						"properties": {
+							"text": "You are a grammar rockstar!",
+							"html": "You are a grammar rockstar!"
+						},
+						"actions": [
+							{
+								"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+								"name": "update",
+								"method": "PUT",
+								"fields": [
+									{
+										"class": [
+											"required"
+										],
+										"type": "hidden",
+										"name": "name",
+										"value": "Level 2"
+									},
+									{
+										"type": "hidden",
+										"name": "description",
+										"value": "Proper use of grammar"
+									},
+									{
+										"type": "text",
+										"name": "feedback",
+										"value": "You are a grammar rockstar!"
+									}
+								]
+							}
+						]
+					}
+				],
+				"links": [
+					{
+						"rel": [
+							"self"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json"
+					},
+					{
+						"rel": [
+							"up"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/overall-levels.json"
+					},
+					{
+						"rel": [
+							"next"
+						],
+						"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/2.json"
+					}
+				],
+				"actions": [
+					{
+						"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+						"name": "update",
+						"method": "PUT",
+						"fields": [
+							{
+								"class": [
+									"required"
+								],
+								"type": "text",
+								"name": "name",
+								"value": "Level 2"
+							},
+							{
+								"type": "hidden",
+								"name": "description",
+								"value": "Proper use of grammar"
+							},
+							{
+								"type": "hidden",
+								"name": "feedback",
+								"value": "You are a grammar rockstar!"
+							}
+						]
+					},
+					{
+						"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+						"name": "delete",
+						"method": "DELETE"
+					}
+				]
+			};
+		}
+	});

--- a/test/components/static-data/rubrics/organizations/custom-points/199/overall-levels/1.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/overall-levels/1.json
@@ -1,0 +1,146 @@
+{
+	"class": [
+		"overall-level"
+	],
+	"rel": [
+		"https://rubrics.api.brightspace.com/rels/overall-level"
+	],
+	"properties": {
+		"name": "Level 2",
+		"rangeStart": 3
+	},
+	"entities": [
+		{
+			"class": [
+				"richtext",
+				"description"
+			],
+			"rel": [
+				"item"
+			],
+			"properties": {
+				"text": "Proper use of grammar",
+                "html": "Proper use of grammar"
+			},
+			"actions": [
+				{
+					"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+					"name": "update",
+					"method": "PUT",
+					"fields": [
+						{
+							"class": [
+								"required"
+							],
+							"type": "hidden",
+							"name": "name",
+							"value": "Level 2"
+						},
+						{
+							"type": "text",
+							"name": "description",
+							"value": "Proper use of grammar"
+						},
+						{
+							"type": "hidden",
+							"name": "feedback",
+							"value": "5 stars for proper use of grammar!"
+						}
+					]
+				}
+			]
+		},
+		{
+			"class": [
+				"richtext",
+				"feedback"
+			],
+			"rel": [
+				"item"
+			],
+			"properties": {
+				"text": "5 stars for proper use of grammar!",
+                "html": "5 stars for proper use of grammar!"
+			},
+			"actions": [
+				{
+					"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+					"name": "update",
+					"method": "PUT",
+					"fields": [
+						{
+							"class": [
+								"required"
+							],
+							"type": "hidden",
+							"name": "name",
+							"value": "Level 2"
+						},
+						{
+							"type": "hidden",
+							"name": "description",
+							"value": "Proper use of grammar"
+						},
+						{
+							"type": "text",
+							"name": "feedback",
+							"value": "5 stars for proper use of grammar!"
+						}
+					]
+				}
+			]
+		}
+	],
+	"links": [
+		{
+			"rel": [
+				"self"
+			],
+			"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json"
+		},
+		{
+			"rel": [
+				"up"
+			],
+			"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/overall-levels.json"
+		},
+		{
+			"rel": [
+				"next"
+			],
+			"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/2.json"
+		}
+    ],
+    "actions": [
+        {
+            "href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+            "name": "update",
+            "method": "PUT",
+            "fields": [
+                {
+                    "class": [
+                        "required"
+                    ],
+                    "type": "text",
+                    "name": "name",
+                    "value": "Level 2"
+                },
+                {
+                    "type": "hidden",
+                    "name": "description",
+                    "value": "Proper use of grammar"
+                },
+                {
+                    "type": "hidden",
+                    "name": "feedback",
+                    "value": "5 stars for proper use of grammar!"
+                }
+            ]
+        },
+        {
+            "href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1.json",
+            "name": "delete",
+            "method": "DELETE"
+        }
+    ]
+}

--- a/test/components/static-data/rubrics/organizations/custom-points/199/overall-levels/2.json
+++ b/test/components/static-data/rubrics/organizations/custom-points/199/overall-levels/2.json
@@ -1,0 +1,60 @@
+{
+	"class": [
+		"overall-level"
+	],
+	"rel": [
+		"https://rubrics.api.brightspace.com/rels/overall-level"
+	],
+	"properties": {
+		"name": "Level 1",
+		"rangeStart": 0
+	},
+	"entities": [
+		{
+			"class": [
+				"richtext",
+				"description"
+			],
+			"rel": [
+				"item"
+			],
+			"properties": {
+				"text": "Proper use of grammar",
+                "html": "Proper use of grammar"
+			}
+		},
+		{
+			"class": [
+				"richtext",
+				"feedback"
+			],
+			"rel": [
+				"item"
+			],
+			"properties": {
+				"text": "5 stars for proper use of grammar!",
+                "html": "5 stars for proper use of grammar!"
+			}
+		}
+	],
+	"links": [
+		{
+			"rel": [
+				"self"
+			],
+			"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/2.json"
+		},
+		{
+			"rel": [
+				"up"
+			],
+			"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/overall-levels.json"
+		},
+		{
+			"rel": [
+				"prev"
+			],
+			"href": "static-data/rubrics/organizations/custom-points/199/overall-levels/1"
+		}
+	]
+}


### PR DESCRIPTION
Note the first 3 files are the main changes here. I also added a set of static-data for custom points. I copied everything in `test/components/text-only` and called it `test/components/custom-points`, then changed those files to be consistent with a custom-points type rubric. Current test only uses one of those files, but I figured we'll need these for future testing on custom-points type rubrics.