### PR TITLE
Us96776 fix points font size

### DIFF
--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -47,10 +47,12 @@
 
 			.points div {
 				margin-left: 0.5rem;
+				@apply --d2l-body-compact-text;
 			}
 
 			:host-context([dir='rtl']) .points div {
 				margin-right: 0.5rem;
+				margin-left: 0;
 			}
 
 		</style>

--- a/editor/d2l-rubric-level-editor.html
+++ b/editor/d2l-rubric-level-editor.html
@@ -36,10 +36,12 @@
 
 			.points div {
 				margin-left: 0.5rem;
+				@apply --d2l-body-compact-text;
 			}
 
 			:host-context([dir='rtl']) .points div {
 				margin-right: 0.5rem;
+				margin-left: 0;
 			}
 
 			[hidden] {

--- a/editor/d2l-rubric-overall-level-editor.html
+++ b/editor/d2l-rubric-overall-level-editor.html
@@ -45,6 +45,10 @@
 				margin-right: 0;
 			}
 
+			.points div {
+				@apply --d2l-body-compact-text;
+			}
+
 			[hidden] {
 				display: none;
 			}


### PR DESCRIPTION
Fixes https://trello.com/c/Ngzvc1G6/4-font-size-for-pts-and-or-more-should-use-body-compact-16px-font-to-match-the-text-fields-contents