### PR TITLE
Fix read-only mode

### DIFF
--- a/assessment-result-behavior.html
+++ b/assessment-result-behavior.html
@@ -67,9 +67,7 @@
 				var criterionEntity = criteriaEntities[i];
 				var selectedCriterionCellEntity = criterionEntity.getSubEntityByClass(this.HypermediaClasses.rubrics.selected);
 
-				if (!this.readOnly) {
-					this._buildRubricToAssessmentMap(assessmentCriterionMap, assessmentCriterionCellMap, criterionEntity);
-				}
+				this._buildRubricToAssessmentMap(assessmentCriterionMap, assessmentCriterionCellMap, criterionEntity);
 				if (!selectedCriterionCellEntity) {
 					// No selected cell in this row, so reset prevLink
 					prevLink = null;
@@ -153,6 +151,9 @@
 				return;
 			}
 			var assessedCriterion = this._assessmentCriterionMap[this._getSelfLink(criterionEntity)];
+			if (!assessedCriterion) {
+				return;
+			}
 			var assessedCriterionFeedback = assessedCriterion.getSubEntityByClass('feedback');
 			if (!assessedCriterionFeedback || !assessedCriterionFeedback.properties) {
 				return;


### PR DESCRIPTION
When we switched to getting feedback from the assessment criterion we need to build that map all the time, before we just got actions from there so didn't need to.