### PR TITLE
Widen gutter to match trash-can halo width

### DIFF
--- a/editor/d2l-rubric-editor-cell-styles.html
+++ b/editor/d2l-rubric-editor-cell-styles.html
@@ -5,7 +5,7 @@
   <template>
 	<style>
 		:host {
-			--d2l-rubric-editor-gutter-width: 2.3rem;
+			--d2l-rubric-editor-gutter-width: calc(2rem + 10px); /* trash can width = 50px including halo */
 
 			--d2l-scroll-wrapper-background-color: var(--d2l-table-header-background-color);
 			--d2l-scroll-wrapper-border-color: var(--d2l-table-border-color);


### PR DESCRIPTION
Gutter was not wide enough to fit trash can halo, so used style rules from `d2l-button` to determine correct width. The gutter is now 4px wider than before (50 vs 46 px).
https://trello.com/c/i9Qt8R3T/9-criterion-row-trashcan-has-blue-focus-border-cut-off-on-right-side