### PR TITLE
Add styling to render HTML editor correctly in description cells

### DIFF
--- a/demo/d2l-rubric-editor.html
+++ b/demo/d2l-rubric-editor.html
@@ -41,6 +41,14 @@
 		</style>
 
 	</custom-style>
+	<style>
+		.d2l-richtext-editor-container.d2l-rubric-html-editor > p:first-of-type {
+			margin-top: 0;
+		}
+		.d2l-richtext-editor-container.d2l-rubric-html-editor > p:last-of-type {
+			margin-bottom: 0;
+		}
+	</style>
 </head>
 <body class="d2l-typography">
 <div class="vertical-section-container">

--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -23,8 +23,6 @@
 
 			d2l-rubric-text-editor {
 				flex-grow: 1;
-				width: 100%;
-				min-height: 4rem;
 			}
 
 			d2l-input-text {

--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -23,6 +23,7 @@
 
 			d2l-rubric-text-editor {
 				flex-grow: 1;
+				min-height: 4rem;
 			}
 
 			d2l-input-text {

--- a/editor/d2l-rubric-feedback-editor.html
+++ b/editor/d2l-rubric-feedback-editor.html
@@ -15,8 +15,8 @@
 				flex-grow: 1;
 
 				--d2l-input-textarea: {
-					display: block;
-					height: 100%;
+					/* display: block; */
+					/* X height: 100%; */
 					min-height: 0;
 					overflow: hidden;
 					hyphens: auto;
@@ -28,9 +28,9 @@
 			}
 
 			d2l-input-textarea {
-				display: block;
-				flex-grow: 1;
-				width: 100%;
+				/* display: block; */
+				/* X flex-grow: 1;
+				width: 100%; */
 			}
 
 		</style>

--- a/editor/d2l-rubric-feedback-editor.html
+++ b/editor/d2l-rubric-feedback-editor.html
@@ -15,8 +15,6 @@
 				flex-grow: 1;
 
 				--d2l-input-textarea: {
-					/* display: block; */
-					/* X height: 100%; */
 					min-height: 0;
 					overflow: hidden;
 					hyphens: auto;
@@ -25,12 +23,6 @@
 
 			* {
 				box-sizing: border-box;
-			}
-
-			d2l-input-textarea {
-				/* display: block; */
-				/* X flex-grow: 1;
-				width: 100%; */
 			}
 
 		</style>

--- a/editor/d2l-rubric-html-editor.html
+++ b/editor/d2l-rubric-html-editor.html
@@ -1,43 +1,60 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../d2l-html-editor/d2l-html-editor-client.html">
 <link rel="import" href="../../d2l-html-editor/d2l-html-editor.html">
-<link rel="import" href="../../d2l-text-input/d2l-text-input-shared-styles.html">
 <link rel="import" href="../../d2l-inputs/d2l-input-shared-styles.html">
 
 <dom-module id="d2l-rubric-html-editor">
 	<template>
-	<style>
+	<style include="d2l-input-styles">
+
+		:host {
+			display: flex;
+			width: 100%;
+		}
 
 		d2l-html-editor {
 			word-break: break-word;
 			word-wrap: break-word;
+			display: flex;
+			width: 100%;
 		}
 
-		d2l-html-editor > .d2l-richtext-editor-container {
+		.d2l-richtext-editor-container {
 			@apply --d2l-input;
-
-			padding: 0.4rem 1rem;
+			@apply --d2l-input-textarea;
+			border-color: transparent;
+			box-shadow: none;
+			border-radius: 0;
+			transition-property: none;
 		}
 
-		d2l-html-editor > .d2l-richtext-editor-container:hover,
-		d2l-html-editor > .d2l-richtext-editor-container:focus,
-		d2l-html-editor > .d2l-richtext-editor-container:active,
-		d2l-html-editor > .d2l-richtext-editor-container.html-editor-container-hover {
-			@apply --d2l-input-hover-disabled;
-
-			padding: calc(0.4rem - 1px) calc(1rem - 1px);
+		.d2l-richtext-editor-container:hover,
+		.d2l-richtext-editor-container:focus,
+		.d2l-richtext-editor-container:active,
+		.d2l-richtext-editor-container.html-editor-container-hover {
+			@apply --d2l-input-hover-focus;
 		}
 
 		d2l-html-editor.invalid > .d2l-richtext-editor-container {
-			border-width: 1px;
-
 			@apply --d2l-input-invalid;
 		}
 
+		/* .d2l-richtext-editor-container p {
+		  margin: 1rem 0;
+		} */
+		d2l-html-editor .d2l-richtext-editor-container > p:last-of-type {
+		  margin-bottom: 0;
+		}
+
+		d2l-html-editor .d2l-richtext-editor-container > p:first-of-type {
+		  margin-top: 0;
+		}
+		/* .d2l-richtext-editor-container p:only-of-type {
+		  margin: 0;
+		} */
+
 		d2l-html-editor.invalid > .d2l-richtext-editor-container:hover,
 		d2l-html-editor.invalid > .d2l-richtext-editor-container:focus {
-			border-width: 2px;
-
 			@apply --d2l-input-invalid;
 		}
 
@@ -47,28 +64,27 @@
 			}
 		}
 	</style>
-	<div class="html-editor-outer-compact">
-		<d2l-html-editor editor-id=[[_uniqueId]]
-						 inline="1"
-						 auto-focus=[[autoFocus]]
-						 auto-focus-end
-						 min-rows="1"
-						 max-rows="1000"
-						 app-root=[[_appRoot]]
-						 lang-tag=[[language]]
-						 fullpage-enabled=0
-						 content=[[_encodeURIComponent(content)]]
-						 toolbar=[[_toolbar]]
-						 plugins=[[_plugins]]
-						 object-resizing=[[objectResizing]]>
-		<div id="toolbar-shortcut" hidden></div>
-		<div class='d2l-richtext-editor-container'
-			id=[[_uniqueId]]
-			role="textbox"
-			placeholder$=[[placeholder]]
-			aria-label$=[[ariaLabel]]></div>
-		</d2l-html-editor>
-	</div>
+	<d2l-html-editor editor-id=[[_uniqueId]]
+					 inline="1"
+					 auto-focus=[[autoFocus]]
+					 auto-focus-end
+					 min-rows="1"
+					 max-rows="1000"
+					 app-root=[[_appRoot]]
+					 lang-tag=[[language]]
+					 fullpage-enabled=0
+					 content=[[_encodeURIComponent(content)]]
+					 toolbar=[[_toolbar]]
+					 plugins=[[_plugins]]
+					 object-resizing=[[objectResizing]]>
+	<div id$="[[_uniqueId]]-toolbar" class="toolbar"></div>
+	<div id$="toolbar-shortcut-[[_uniqueId]]" hidden></div>
+	<div class='d2l-richtext-editor-container'
+		id=[[_uniqueId]]
+		role="textbox"
+		placeholder$=[[placeholder]]
+		aria-label$=[[ariaLabel]]></div>
+	</d2l-html-editor>
 	</template>
 
 	<script>
@@ -165,6 +181,9 @@
 			_encodeURIComponent: function(content) {
 				return content ? encodeURIComponent(content) : '';
 			},
+			_generateUniqueId: function(clzz) {
+				return clzz + this._uniqueId;
+			}
 		});
 	</script>
 </dom-module>

--- a/editor/d2l-rubric-text-editor.html
+++ b/editor/d2l-rubric-text-editor.html
@@ -28,12 +28,6 @@
 			box-sizing: border-box;
 		}
 
-		d2l-input-textarea {
-			/* display: block; */
-			/* X flex-grow: 1;
-			width: 100%; */
-		}
-
 	</style>
 		<template is="dom-if" if="[[!enableHtmlEditor]]">
 			<d2l-input-textarea
@@ -84,7 +78,7 @@
 				},
 				enableHtmlEditor: {
 					type: Boolean,
-					value: true,
+					value: false,
 				},
 				disabled: {
 					type: Boolean,

--- a/editor/d2l-rubric-text-editor.html
+++ b/editor/d2l-rubric-text-editor.html
@@ -12,8 +12,6 @@
 
 			--d2l-input-textarea: {
 
-				/* display: block;
-				height: 100%; */
 				min-height: 0;
 				overflow: hidden;
 				hyphens: auto;

--- a/editor/d2l-rubric-text-editor.html
+++ b/editor/d2l-rubric-text-editor.html
@@ -9,12 +9,11 @@
 		:host {
 			line-height: 1rem;
 			display: flex;
-			flex-grow: 1;
 
 			--d2l-input-textarea: {
 
-				display: block;
-				height: 100%;
+				/* display: block;
+				height: 100%; */
 				min-height: 0;
 				overflow: hidden;
 				hyphens: auto;
@@ -30,9 +29,9 @@
 		}
 
 		d2l-input-textarea {
-			display: block;
-			flex-grow: 1;
-			width: 100%;
+			/* display: block; */
+			/* X flex-grow: 1;
+			width: 100%; */
 		}
 
 	</style>
@@ -85,7 +84,7 @@
 				},
 				enableHtmlEditor: {
 					type: Boolean,
-					value: false,
+					value: true,
 				},
 				disabled: {
 					type: Boolean,


### PR DESCRIPTION
Some issues I'm still aware of:

1. The top/bottom margins of the first/last paragraph in an HTML editor still set to the default of 1rem, which makes there appear to be too much spacing.  I wasn't able to correct this within the components, due to the way that Polymer adds style scopes to all it's component css rules. The paragraphs added by TinyMCE don't get the scopes so we can't style them from within the component. We may just have to hack it by adding styling to the main rubric page. You can see an example of the styles required in main document of the rubric editor demo page.

2. The HTML 5 Drag API drag image seems to be screwed up in Chrome. Possibly related to the TinyMCE contenteditable div. Not sure. Will have to come back to it.

3. I cleaned up some of the existing styles (heights/widths/flex properties) on some of our components particularly relating to d2l-input-textarea, as they no longer seemed to be necessary and was trying to keep things clean and simple so that it was easier to understand what needed to be added to make the HTML editor content area styled correctly.

4. I've left the default as HTML editing disabled. There are some weird bugs in the unit tests due to a null editor in some of the HTML editor detach code. This also seems to happen when dragging/dropping. Will try and look at that before I leave today to see if it is an easy fix.

5. I have not done much testing with custom points yet. With some basic testing, it seemed to render OK, but might need some tweaking.