### PR TITLE
US96680 - HTML editor: Save and Load description content

### DIFF
--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -97,7 +97,6 @@
 					type: String,
 					value: ''
 				},
-
 				_canEditDescription: {
 					type: Boolean,
 					computed: '_computeCanEditDescription(entity)',
@@ -142,7 +141,7 @@
 
 			_getDescription: function(entity) {
 				var description = entity && entity.getSubEntityByClass(this.HypermediaClasses.rubrics.description);
-				return description && description.properties && description.properties.text || '';
+				return description && description.properties && description.properties.html || '';
 			},
 
 			_saveDescription: function(e) {

--- a/editor/d2l-rubric-html-editor.html
+++ b/editor/d2l-rubric-html-editor.html
@@ -73,7 +73,7 @@
 					 app-root=[[_appRoot]]
 					 lang-tag=[[language]]
 					 fullpage-enabled=0
-					 content=[[_encodeURIComponent(content)]]
+					 content=[[_encodeURIComponent(initValue)]]
 					 toolbar=[[_toolbar]]
 					 plugins=[[_plugins]]
 					 object-resizing=[[objectResizing]]>
@@ -84,6 +84,7 @@
 		role="textbox"
 		placeholder$=[[placeholder]]
 		aria-label$=[[ariaLabel]]
+		on-focus="_handleFocus"
 		on-blur="_handleBlur"></div>
 	</d2l-html-editor>
 	</template>
@@ -103,9 +104,6 @@
 					value: function() {
 						return 'htmleditor-' + Date.now();
 					},
-				},
-				content: {
-					type: String,
 				},
 				ariaLabel: {
 					type: String,
@@ -129,6 +127,9 @@
 				},
 				maxRows: {
 					type: Number,
+				},
+				initValue: {
+					type: String,
 				},
 				value: {
 					type: String,
@@ -155,16 +156,13 @@
 					value: false,
 				},
 			},
-			observers: [
-				'_initializeValue(content)',
-			],
 			attached: function() {
 				Polymer.RenderStatus.afterNextRender(this, function() {
-					this.listen(this.$$('d2l-html-editor'), 'change', '_valueChanged');
+					this.listen(this.$$('d2l-html-editor'), 'change', '_contentChanged');
 				}.bind(this));
 			},
 			detached: function() {
-				this.unlisten(this.$$('d2l-html-editor'), 'change', '_valueChanged');
+				this.unlisten(this.$$('d2l-html-editor'), 'change', '_contentChanged');
 			},
 			focus: function() {
 				this.$$('d2l-html-editor').focus();
@@ -176,23 +174,24 @@
 				var htmlEditor = this.$$('d2l-html-editor');
 				this.toggleClass('invalid', isInvalid, htmlEditor);
 			},
-			_encodeURIComponent: function(content) {
-				return content ? encodeURIComponent(content) : '';
+			_encodeURIComponent: function(value) {
+				return value ? encodeURIComponent(value) : '';
 			},
-			_generateUniqueId: function(clzz) {
-				return clzz + this._uniqueId;
-			},
-			_initializeValue: function(content) {
-				this.value = content;
-			},
-			_valueChanged: function(e) {
-				// Change event will be fired 'onBlur' instead to match default behavior of TEXTAREAs
+			_contentChanged: function(e) {
+				// Stop change event from propagating as we instead fire a
+				// 'change' event on an 'onBlur' to match the default behavior of TEXTAREAs.
 				e.stopPropagation();
 			},
-			_handleBlur: function() {
-				var newValue = this._getContent();
-				if (this.value !== newValue) {
-					this.value = newValue;
+			_handleFocus: function() {
+				if (this.value === undefined || this.value === null) {
+					this.value = this._getContent();
+				}
+			},
+			_handleBlur: function(e) {
+				var hasContentChanged = this._getContent() !== this.value;
+				var emojiCausedBlur = e.relatedTarget && e.relatedTarget.hasAttribute('data-d2l-emoji');
+				if (hasContentChanged && !emojiCausedBlur) {
+					this.value = this._getContent();
 					this.dispatchEvent(new CustomEvent(
 						'change',
 						{bubbles: true, composed: true}

--- a/editor/d2l-rubric-html-editor.html
+++ b/editor/d2l-rubric-html-editor.html
@@ -1,7 +1,6 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../d2l-html-editor/d2l-html-editor-client.html">
 <link rel="import" href="../../d2l-html-editor/d2l-html-editor.html">
-<link rel="import" href="../../d2l-text-input/d2l-text-input-shared-styles.html">
 <link rel="import" href="../../d2l-inputs/d2l-input-shared-styles.html">
 
 <dom-module id="d2l-rubric-html-editor">
@@ -66,7 +65,8 @@
 			id=[[_uniqueId]]
 			role="textbox"
 			placeholder$=[[placeholder]]
-			aria-label$=[[ariaLabel]]></div>
+			aria-label$=[[ariaLabel]]
+			on-blur="_handleBlur"></div>
 		</d2l-html-editor>
 	</div>
 	</template>
@@ -87,6 +87,9 @@
 						return 'htmleditor-' + Date.now();
 					},
 				},
+				content: {
+					type: String,
+				},
 				ariaLabel: {
 					type: String,
 				},
@@ -101,7 +104,7 @@
 				},
 				autoFocus: {
 					type: Number,
-					value: 1,
+					value: 0,
 				},
 				minRows: {
 					type: Number,
@@ -109,6 +112,9 @@
 				},
 				maxRows: {
 					type: Number,
+				},
+				value: {
+					type: String,
 				},
 				_appRoot: {
 					type: String,
@@ -118,10 +124,6 @@
 				},
 				placeholder: {
 					type: String,
-				},
-				content: {
-					type: String,
-					observer: '_contentChanged',
 				},
 				_toolbar: {
 					type: String,
@@ -136,6 +138,9 @@
 					value: false,
 				},
 			},
+			observers: [
+				'_initializeValue(content)',
+			],
 			attached: function() {
 				Polymer.RenderStatus.afterNextRender(this, function() {
 					this.listen(this.$$('d2l-html-editor'), 'change', '_valueChanged');
@@ -144,19 +149,11 @@
 			detached: function() {
 				this.unlisten(this.$$('d2l-html-editor'), 'change', '_valueChanged');
 			},
-			_valueChanged: function(e) {
-				this.fire('value-changed', {value: e.detail.content});
-			},
 			focus: function() {
 				this.$$('d2l-html-editor').focus();
 			},
-			getContent: function() {
+			_getContent: function() {
 				return this.$$('d2l-html-editor').getContent();
-			},
-			_contentChanged: function(newValue, oldValue) {
-				if (this._uniqueId && oldValue && newValue === '') {
-					this.$$('d2l-html-editor').clearContent();
-				}
 			},
 			_invalidChanged: function(isInvalid) {
 				var htmlEditor = this.$$('d2l-html-editor');
@@ -165,6 +162,23 @@
 			_encodeURIComponent: function(content) {
 				return content ? encodeURIComponent(content) : '';
 			},
+			_initializeValue: function(content) {
+				this.value = content;
+			},
+			_valueChanged: function(e) {
+				// Change event will be fired 'onBlur' instead to match default behavior of TEXTAREAs
+				e.stopPropagation();
+			},
+			_handleBlur: function() {
+				var newValue = this._getContent();
+				if (this.value !== newValue) {
+					this.value = newValue;
+					this.dispatchEvent(new CustomEvent(
+						'change',
+						{bubbles: true, composed: true}
+					));
+				}
+			}
 		});
 	</script>
 </dom-module>

--- a/editor/d2l-rubric-text-editor.html
+++ b/editor/d2l-rubric-text-editor.html
@@ -44,11 +44,10 @@
 				id="htmlEditor"
 				hidden$=[[!enableHtmlEditor]]
 				aria-label=[[ariaLabel]]
-				invalid=[[ariaInvalid]]
-				error-message=[[errorMessage]]
+				invalid=[[_stringIsTrue(ariaInvalid)]]
 				language=[[language]]
 				placeholder=[[placeholder]]
-				content=[[value]]
+				init-value=[[value]]
 				min-rows=[[minRows]]
 				max-rows=[[maxRows]]
 			></d2l-rubric-html-editor>
@@ -89,6 +88,9 @@
 				} else {
 					this.$$('#textEditor').focus();
 				}
+			},
+			_stringIsTrue: function(string) {
+				return string && string === 'true';
 			}
 		});
 	</script>

--- a/editor/d2l-rubric-text-editor.html
+++ b/editor/d2l-rubric-text-editor.html
@@ -98,13 +98,6 @@
 				} else {
 					this.$$('#textEditor').focus();
 				}
-			},
-			getContent: function() {
-				if (this.enableHtmlEditor) {
-					return this.$$('#htmlEditor').getContent();
-				} else {
-					return this.$$('#textEditor').getContent();
-				}
 			}
 		});
 	</script>


### PR DESCRIPTION
- If HTML is enabled, content saves when a description editor onBlur event occurs, matching the behavior of the textarea.

- Checked that HTML editor and non-html editor still save and load descriptions (including emojis) correctly.
- Checked that when creating description using html editor, then turning html-editor off and vice versa, content still shows up correctly. In the case where html-editor was on when it was created, then turned off, we will see the tags similar to what happens when editing an html post in Activity Feed `<p>abc</p>`
- Checked that description saving fail causes failed tooltip to appear.


Bugs:
- Selecting an emoticon to insert from the popup counts as a focus-out, so it's triggering a save