### PR TITLE
Fix html-editor not updating to reflect content after cell shifted

### DIFF
--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -154,6 +154,7 @@
 				<template is="dom-repeat" as="criterionCell" items="[[_getCriterionCells(entity)]]" >
 					<div class="cell">
 						<d2l-rubric-description-editor
+							key="[[_criterionCellKey()]]"
 							href="[[_getSelfLink(criterionCell)]]"
 							token="[[token]]"
 							aria-label-langterm="criterionDescriptionAriaLabel"
@@ -390,7 +391,11 @@
 			},
 
 			_isOutOfEditable: function(entity) {
-				return this.hasOutOf && entity && entity.hasActionByName("update-outof");
+				return this.hasOutOf && entity && entity.hasActionByName('update-outof');
+			},
+
+			_criterionCellKey: function() {
+				return [this.HypermediaRels.Rubrics.level, 'self'];
 			}
 		});
 	</script>

--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -67,6 +67,7 @@
 		</div>
 		<d2l-rubric-text-editor
 			id="description"
+			key="[[_computedKey]]"
 			aria-invalid="[[_isAriaInvalid(_descriptionInvalid)]]"
 			aria-label="[[_getAriaLabel(ariaLabelLangterm, criterionName, entity.properties)]]"
 			disabled="[[!_canEditDescription]]"
@@ -98,6 +99,13 @@
 				criterionName: {
 					type: String,
 					value: ''
+				},
+				key: {
+					type: Array,
+				},
+				_computedKey: {
+					type: String,
+					computed: '_constructKey(key, entity)',
 				},
 				_canEditDescription: {
 					type: Boolean,
@@ -227,6 +235,17 @@
 				return new Boolean(valueInvalid).toString();
 			},
 
+			_constructKey: function(key, entity) {
+				var constructed = '';
+				if (entity && entity.hasLinkByRel) {
+					key.forEach(function(rel) {
+						if (entity.hasLinkByRel(rel)) {
+							constructed += entity.getLinkByRel(rel).href;
+						}
+					});
+				}
+				return constructed;
+			}
 		});
 	</script>
 </dom-module>

--- a/editor/d2l-rubric-html-editor.html
+++ b/editor/d2l-rubric-html-editor.html
@@ -65,6 +65,7 @@
 		}
 	</style>
 	<d2l-html-editor editor-id=[[_uniqueId]]
+					 key=[[key]]
 					 inline="1"
 					 auto-focus=[[autoFocus]]
 					 auto-focus-end
@@ -73,7 +74,7 @@
 					 app-root=[[_appRoot]]
 					 lang-tag=[[language]]
 					 fullpage-enabled=0
-					 content=[[_encodeURIComponent(initValue)]]
+					 content=[[_encodeURIComponent(value)]]
 					 toolbar=[[_toolbar]]
 					 plugins=[[_plugins]]
 					 object-resizing=[[objectResizing]]>
@@ -84,7 +85,6 @@
 		role="textbox"
 		placeholder$=[[placeholder]]
 		aria-label$=[[ariaLabel]]
-		on-focus="_handleFocus"
 		on-blur="_handleBlur"></div>
 	</d2l-html-editor>
 	</template>
@@ -128,10 +128,10 @@
 				maxRows: {
 					type: Number,
 				},
-				initValue: {
+				value: {
 					type: String,
 				},
-				value: {
+				key: {
 					type: String,
 				},
 				_appRoot: {
@@ -145,11 +145,11 @@
 				},
 				_toolbar: {
 					type: String,
-					value: 'bold italic underline bullist d2l_emoticons',
+					value: 'bold italic bullist',
 				},
 				_plugins: {
 					type: String,
-					value: 'lists paste d2l_placeholder d2l_emoticons d2l_filter',
+					value: 'lists paste d2l_placeholder d2l_filter',
 				},
 				objectResizing: {
 					type: Boolean,
@@ -182,13 +182,8 @@
 				// 'change' event on an 'onBlur' to match the default behavior of TEXTAREAs.
 				e.stopPropagation();
 			},
-			_handleFocus: function() {
-				if (this.value === undefined || this.value === null) {
-					this.value = this._getContent();
-				}
-			},
 			_handleBlur: function(e) {
-				var hasContentChanged = this._getContent() !== this.value;
+				var hasContentChanged = this._decodeHtml(this._getContent()) !== this._decodeHtml(this.value);
 				var emojiCausedBlur = e.relatedTarget && e.relatedTarget.hasAttribute('data-d2l-emoji');
 				if (hasContentChanged && !emojiCausedBlur) {
 					this.value = this._getContent();
@@ -197,6 +192,12 @@
 						{bubbles: true, composed: true}
 					));
 				}
+			},
+			_decodeHtml: function decodeHtml(html) {
+				if (!html) return '';
+				var txt = document.createElement('textarea');
+				txt.innerHTML = html;
+				return txt.value;
 			}
 		});
 	</script>

--- a/editor/d2l-rubric-overall-levels-editor.html
+++ b/editor/d2l-rubric-overall-levels-editor.html
@@ -171,6 +171,7 @@
 					<template is="dom-repeat" items="[[_overallLevels]]" as="overallLevel">
 						<div class="cell">
 							<d2l-rubric-description-editor
+								key="[[_overallLevelKey()]]"
 								href="[[_getSelfLink(overallLevel)]]"
 								token="[[token]]"
 								aria-label-langterm="overallDescriptionAriaLabel"
@@ -259,6 +260,9 @@
 				Polymer.RenderStatus.afterNextRender(this, function() {
 					this.$$('d2l-scroll-wrapper').notifyResize();
 				}.bind(this));
+			},
+			_overallLevelKey: function() {
+				return ['self'];
 			}
 		});
 	</script>

--- a/editor/d2l-rubric-text-editor.html
+++ b/editor/d2l-rubric-text-editor.html
@@ -47,7 +47,8 @@
 				invalid=[[_stringIsTrue(ariaInvalid)]]
 				language=[[language]]
 				placeholder=[[placeholder]]
-				init-value=[[value]]
+				value=[[value]]
+				key=[[key]]
 				min-rows=[[minRows]]
 				max-rows=[[maxRows]]
 			></d2l-rubric-html-editor>
@@ -58,6 +59,7 @@
 		Polymer({
 			is: 'd2l-rubric-text-editor',
 			properties: {
+				key: String,
 				language: String,
 				ariaLabel: {
 					type: String,


### PR DESCRIPTION
Pass a key that is unique for description (criterion and overallevel) cell. It is based off the entity self href or level + self href (in the case of criterionCell as they are always 0, 1, 2...)
When a cell is shifted and the html-editor is re-used, the shifted cell will pick up a new key value. This will notify the html-editor that it needs to re-set content to reflect its new value.