### PR TITLE
Adjust margin for group footer

### DIFF
--- a/editor/d2l-rubric-criteria-groups-editor.html
+++ b/editor/d2l-rubric-criteria-groups-editor.html
@@ -12,7 +12,7 @@
 
 <dom-module id="d2l-rubric-criteria-groups-editor">
 	<template strip-whitespace>
-		<style>
+		<style include="d2l-rubric-editor-cell-styles">
 			:host {
 				display: block;
 			}
@@ -26,7 +26,7 @@
 				flex-direction: row;
 				justify-content: space-between;
 				align-items: center;
-				margin: 0 2.2rem;
+				margin: 0 var(--d2l-rubric-editor-gutter-width);
 			}
 
 			.out-of-text {


### PR DESCRIPTION
Addresses https://trello.com/c/OrK6v4yL/40-add-criteria-group-and-rubric-total-score-slightly-overhang-left-right-alignment by setting margin to gutter width.