### PR TITLE
Styling polish

### DIFF
--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -53,6 +53,9 @@
 			.d2l-alert-container:last-of-type {
 				padding-bottom: 1px;
 			}
+			.d2l-alert-container {
+				padding: 0 var(--d2l-rubric-editor-gutter-width);
+			}
 		</style>
 
 		<template is="dom-repeat" items="[[_alerts]]">

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -98,7 +98,7 @@
 			.criterion-detail .criterion-feedback-header {
 				@apply --d2l-body-compact-text;
 				flex: 0 0 auto;
-				padding: 0.3rem;
+				padding: 0.3rem 0.5rem;
 				font-weight: 700;
 			}
 

--- a/editor/d2l-rubric-editor-menu.html
+++ b/editor/d2l-rubric-editor-menu.html
@@ -5,21 +5,27 @@
 
 <dom-module id="d2l-rubric-editor-menu">
 	<template strip-whitespace>
-		<style>
+		<style include="d2l-rubric-editor-cell-styles">
 			:host {
 				display: flex;
 				flex-direction: row;
 				justify-content: flex-end;
 				overflow: hidden;
 				padding-top: 0.5rem;
-				padding-bottom: 1.1rem;
-				padding-right: 46px;
+				padding-bottom: 0.7rem;
+				padding-right: calc( var(--d2l-rubric-editor-gutter-width) - 0.6rem );
+			}
+			:host[is-holistic] {
+				padding-right: calc( var(--d2l-rubric-editor-gutter-width) + 42px );
 			}
 			[hidden] {
 				display: none;
 			}
 			:host(:dir(rtl)) {
-				padding-left: 46px;
+				padding-left: calc( var(--d2l-rubric-editor-gutter-width) - 0.6rem );
+			}
+			:host(:dir(rtl))[is-holistic] {
+				padding-left: calc( var(--d2l-rubric-editor-gutter-width) + 42px );
 			}
 		</style>
 
@@ -39,6 +45,11 @@
 					type: Boolean,
 					value: false
 				},
+				isHolistic: {
+					type: Boolean,
+					value: false,
+					reflectToAttribute: true
+				}
 			},
 			behaviors: [
 				D2L.PolymerBehaviors.Rubric.LocalizeBehavior

--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -77,7 +77,8 @@ Creates and edits a rubric
 		<div id="rubric-editor-container" hidden >
 			<d2l-rubric-editor-menu
 				on-d2l-rubric-reverse-levels="_handleReverseLevels"
-				reverse-levels-enabled="[[_present(_reverseLevels)]]">
+				reverse-levels-enabled="[[_present(_reverseLevels)]]"
+				is-holistic="[[_isHolistic]]">
 			</d2l-rubric-editor-menu>
 
 			<d2l-rubric-criteria-groups-editor

--- a/editor/d2l-rubric-levels-editor.html
+++ b/editor/d2l-rubric-levels-editor.html
@@ -51,8 +51,7 @@
 				--d2l-button-icon-min-height: 100%;
 			}
 			[is-holistic] d2l-button-icon {
-				background-color: var(--d2l-table-body-background-color);
-				--d2l-button-icon-min-width: 1.6rem;
+				background-color: var(--d2l-color-regolith);
 			}
 			.col-first {
 				display: flex;

--- a/editor/d2l-rubric-overall-levels-editor.html
+++ b/editor/d2l-rubric-overall-levels-editor.html
@@ -23,16 +23,18 @@
 
 			.gutter-left {
 				margin-left: calc(var(--d2l-rubric-editor-gutter-width) - 0.3rem);
+				margin-right: 0.5rem;
 			}
 			:dir(rtl) .gutter-left {
-				margin-left: 0;
+				margin-left: 0.5rem;
 				margin-right: calc(var(--d2l-rubric-editor-gutter-width) - 0.3rem);
 			}
 			.gutter-right {
 				margin-right: calc(var(--d2l-rubric-editor-gutter-width) - 0.3rem);
+				margin-left: 0.5rem;
 			}
 			:dir(rtl) .gutter-right {
-				margin-right: 0;
+				margin-right: 0.5rem;
 				margin-left: calc(var(--d2l-rubric-editor-gutter-width) - 0.3rem);
 			}
 			.gutter-left, .gutter-right {
@@ -68,7 +70,6 @@
 				border: 1px solid var(--d2l-color-mica);
 				height: 100%;
 				align-items: center;
-				--d2l-button-icon-min-width: 1.6rem;
 				--d2l-button-icon-min-height: 100%;
 			}
 


### PR DESCRIPTION
Addresses
https://trello.com/c/V7ALVNpw/44-ui-polish-holistic-add-level-buttons-need-tweaks
https://trello.com/c/BUVR7ErZ/45-ui-polish-holistic-initial-feedback-shift-text-right-by-2px-should-align-with-level-name-input
https://trello.com/c/39jnCged/46-ui-polish-holistic-reverse-level-order-tweaks

and indirectly this one too, since this is fixed by the top trello regarding the buttons above
https://trello.com/c/yPwtXLqV/14-ipad-holistic-rubric-overall-level-component-add-buttons-both-append-and-prepend-plus-sign-is-not-centered

and partially addresses this one too, though only the alignment to the table, not the full width issue
https://trello.com/c/36rvBxhC/33-something-went-wrong-element-width-went-wrong