### PR TITLE
fix duplicate invalid tooltips

### DIFF
--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -88,8 +88,9 @@
 						hidden="[[!showGroupName]]"
 						disabled="[[!_canEditGroupName(entity)]]"
 						on-change="_saveName"
+						aria-invalid="[[_isAriaInvalid(_nameInvalid)]]"
 						aria-label$="[[localize('groupName')]]"
-						required prevent-submit>
+						prevent-submit>
 					</d2l-input-text>
 				</d2l-rubric-levels-editor>
 				<template is="dom-if" if="[[_nameInvalid]]">
@@ -228,6 +229,10 @@
 				} else {
 					this.set(invalidId, false);
 				}
+			},
+
+			_isAriaInvalid: function(nameInvalid) {
+				return new Boolean(nameInvalid).toString();
 			},
 
 			_notifyResize: function() {

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -406,14 +406,16 @@
 				var action = this.entity.getActionByName('delete');
 				if (action) {
 					var deleteButton = e.currentTarget;
-					deleteButton.disabled = true;
+					deleteButton.setAttribute('disabled', '');
 					var name = this.entity.properties.name;
 					this._transitionElement(this, 0);
 					this.fire('iron-announce', { text: this.localize('criterionDeleted', 'name', name) }, { bubbles: true });
 					this.performSirenAction(action).then(function() {
 						this.fire('d2l-rubric-criterion-deleted');
-					}.bind(this)).finally(function() {
-						deleteButton.disabled = false;
+					}.bind(this)).then(function() {
+						deleteButton.removeAttribute('disabled');
+					}).catch(function() {
+						deleteButton.removeAttribute('disabled');
 					});
 				}
 			},

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -165,8 +165,7 @@
 				hover-styles
 				value=[[entity.properties.name]]
 				placeholder="[[_getNamePlaceholder(localize, displayNamePlaceholder)]]"
-				on-change="_saveName"
-				required="[[_nameRequired]]">
+				on-change="_saveName">
 			</d2l-input-textarea>
 			<template is="dom-if" if="[[_nameInvalid]]">
 				<d2l-tooltip for="name" position="bottom">[[_nameInvalidError]]</d2l-tooltip>

--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -64,7 +64,6 @@
 				aria-label="[[localize('cellPoints')]]"
 				disabled="[[!_canEditPoints]]"
 				size="1"
-				required="[[_pointsRequired]]"
 				prevent-submit>
 			</d2l-input-text>
 			<div>[[localize('pointsAbbreviation')]]</div>

--- a/editor/d2l-rubric-level-editor.html
+++ b/editor/d2l-rubric-level-editor.html
@@ -280,13 +280,15 @@
 				var action = this.entity.getActionByName('delete');
 				if (action) {
 					var deleteButton = e.currentTarget;
-					deleteButton.disabled = true;
+					deleteButton.setAttribute('disabled', '');
 					var name = this.entity.properties.name;
 					this.fire('iron-announce', { text: this.localize('levelDeleted', 'name', name) }, { bubbles: true });
 					this.performSirenAction(action).then(function() {
 						this.fire('d2l-rubric-level-deleted');
-					}.bind(this)).finally(function() {
-						deleteButton.disabled = false;
+					}.bind(this)).then(function() {
+						deleteButton.removeAttribute('disabled');
+					}).catch(function() {
+						deleteButton.removeAttribute('disabled');
 					});
 				}
 			}

--- a/editor/d2l-rubric-level-editor.html
+++ b/editor/d2l-rubric-level-editor.html
@@ -74,7 +74,6 @@
 			aria-invalid="[[_isAriaInvalid(_nameInvalid)]]"
 			aria-label="[[localize('levelName')]]"
 			disabled="[[!_canEditName]]"
-			required="[[_nameRequired]]"
 			prevent-submit>
 		</d2l-input-text>
 		<div class="operations" noPoints$=[[!_showPoints]]>
@@ -87,7 +86,6 @@
 					aria-label="[[localize('levelPoints')]]"
 					disabled="[[!_canEditPoints]]"
 					size="1"
-					required="[[_pointsRequired]]"
 					prevent-submit>
 				</d2l-input-text>
 				<div>[[_getPointsUnitText(entity)]]</div>

--- a/editor/d2l-rubric-overall-level-editor.html
+++ b/editor/d2l-rubric-overall-level-editor.html
@@ -61,7 +61,6 @@
 			aria-invalid="[[_isAriaInvalid(_nameInvalid)]]"
 			aria-label="[[localize('overallLevelName')]]"
 			disabled="[[!_canEditName]]"
-			required="[[_nameRequired]]"
 			prevent-submit>
 		</d2l-input-text>
 		<div class="operations" text-only$="[[!_hasRangeStart]]">
@@ -74,7 +73,6 @@
 					aria-label="[[localize('overallLevelRangeStart')]]"
 					disabled="[[!_canEditRangeStart]]"
 					size="1"
-					required="[[_rangeStartRequired]]"
 					prevent-submit>
 				</d2l-input-text>
 				<div>[[localize('rangeStartOrMore')]]</div>

--- a/editor/d2l-rubric-overall-level-editor.html
+++ b/editor/d2l-rubric-overall-level-editor.html
@@ -232,14 +232,16 @@
 				var action = this.entity.getActionByName('delete');
 				if (action) {
 					var deleteButton = e.currentTarget;
-					deleteButton.disabled = true;
+					deleteButton.setAttribute('disabled', '');
 					var name = this.entity.properties.name;
 					this.fire('iron-announce', { text: this.localize('overallLevelDeleted', 'name', name) }, { bubbles: true });
 					this.performSirenAction(action).then(function() {
 						this.fire('d2l-rubric-overall-level-deleted');
 
-					}.bind(this)).finally(function() {
-						deleteButton.disabled = false;
+					}.bind(this)).then(function() {
+						deleteButton.removeAttribute('disabled');
+					}).catch(function() {
+						deleteButton.removeAttribute('disabled');
 					});
 				}
 			}


### PR DESCRIPTION
Fixes https://trello.com/c/xWQadvGj/43-for-the-required-field-we-are-still-seeing-the-duplicate-error-message
Note it did not require changes to d2l-inputs after all, as that component already contained the code that was supposed to handle this. For some reason that code no longer worked because the 'invalid' event was no longer being trapped. 
Instead, this solution stops setting the 'required' field of the text input and textarea components, since the only thing setting that was accomplishing was getting those unwanted tooltips. The red borders are obtained by setting 'aria-invalid' instead.