### PR TITLE
ensure HTML editor save events are handled consistently by preventing…

### DIFF
--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -231,6 +231,7 @@
 				icon="d2l-tier1:delete"
 				text="[[localize('removeCriterion', 'name', entity.properties.name)]]"
 				on-tap="_handleDeleteCriterion"
+				type="button"
 			></d2l-button-icon>
 		</div>
 	</template>

--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -152,7 +152,7 @@
 				window.D2L.Hypermedia.HMConstantsBehavior,
 				D2L.PolymerBehaviors.Rubric.LocalizeBehavior
 			],
-			_onEntityChanged: function(entity) {
+			_onEntityChanged: function() {
 				this._descriptionInvalid = false;
 				this._pointsInvalid = false;
 			},
@@ -248,6 +248,7 @@
 					keyLinkRels.forEach(function(rel) {
 						if (entity.hasLinkByRel(rel)) {
 							constructed += entity.getLinkByRel(rel).href;
+							constructed += '|';
 						}
 					});
 				}

--- a/editor/d2l-rubric-level-editor.html
+++ b/editor/d2l-rubric-level-editor.html
@@ -97,7 +97,8 @@
 				icon="d2l-tier1:delete"
 				text="[[localize('removeLevel', 'name', entity.properties.name)]]"
 				on-tap="_handleDeleteLevel"
-				hidden="[[!_canDelete]]">
+				hidden="[[!_canDelete]]"
+				type="button">
 			</d2l-button-icon>
 		</div>
 		<template is="dom-if" if="[[_nameInvalid]]">

--- a/editor/d2l-rubric-levels-editor.html
+++ b/editor/d2l-rubric-levels-editor.html
@@ -93,7 +93,8 @@
 				on-focus="_onPrependFocus"
 				icon="d2l-tier2:add"
 				text="[[localize('addLevelPrepend', 'name', '')]]"
-				disabled="[[!_canPrepend]]">
+				disabled="[[!_canPrepend]]"
+				type="button">
 			</d2l-button-icon>
 		</div>
 		<template is="dom-repeat" items="[[_levels]]" as="level">
@@ -112,7 +113,8 @@
 				on-focus="_onAppendFocus"
 				icon="d2l-tier2:add"
 				text="[[localize('addLevelAppend', 'name', '')]]"
-				disabled="[[!_canAppend]]">
+				disabled="[[!_canAppend]]"
+				type="button">
 			</d2l-button-icon>
 		</div>
 		<div class="gutter-right"></div>

--- a/editor/d2l-rubric-overall-level-editor.html
+++ b/editor/d2l-rubric-overall-level-editor.html
@@ -84,7 +84,8 @@
 				icon="d2l-tier1:delete"
 				text="[[localize('removeOverallLevel', 'name', entity.properties.name)]]"
 				on-tap="_handleDeleteLevel"
-				hidden="[[!_canDelete]]">
+				hidden="[[!_canDelete]]"
+				type="button">
 			</d2l-button-icon>
 		</div>
 		<template is="dom-if" if="[[_nameInvalid]]">

--- a/editor/d2l-rubric-overall-levels-editor.html
+++ b/editor/d2l-rubric-overall-levels-editor.html
@@ -166,7 +166,8 @@
 				<div class="gutter-left">
 					<d2l-button-icon on-tap="_handlePrependOverallLevel"
 						on-focus="_onPrependFocus" icon="d2l-tier2:add" text="[[localize('addOverallLevelPrepend', 'name', '')]]"
-						disabled="[[!_canPrepend]]">
+						disabled="[[!_canPrepend]]"
+						type="button">
 					</d2l-button-icon>
 				</div>
 				<div class="col-center">
@@ -179,7 +180,8 @@
 				<div class="gutter-right">
 					<d2l-button-icon on-tap="_handleAppendOverallLevel"
 						on-focus="_onAppendFocus" icon="d2l-tier2:add" text="[[localize('addOverallLevelAppend', 'name', '')]]"
-					 	disabled="[[!_canAppend]]">
+					 	disabled="[[!_canAppend]]"
+						type="button">
 					</d2l-button-icon>
 				</div>
 			</div>

--- a/editor/d2l-rubric-text-editor.html
+++ b/editor/d2l-rubric-text-editor.html
@@ -99,18 +99,17 @@
 			_onInputChange: function(e) {
 				e.stopPropagation();
 				var value = (e.detail && e.detail.content) || e.target.value || '';
-				if (this._decodeHtml(value) !== this._decodeHtml(this.value)) {
-					this.debounce('fireInputChange', function() {
-						this.fire('change', { value: value });
-					}, 1000);
 
-					var activeElementId = document.activeElement && document.activeElement.id;
-					var focusedOnInput = activeElementId && e.target.querySelector('#' + activeElementId);
-					// If it is a blur event (no longer focused on input), fire change event immediately to
-					// avoid race conditions with other events.
-					if (!focusedOnInput) {
-						this.flushDebouncer('fireInputChange');
-					}
+				this.debounce('fireInputChange', function() {
+					this.fire('change', { value: value });
+				}, 1000);
+
+				var activeElementId = document.activeElement && document.activeElement.id;
+				var focusedOnInput = activeElementId && e.target.querySelector('#' + activeElementId);
+				// If it is a blur event (no longer focused on input), fire change event immediately to
+				// avoid race conditions with other events.
+				if (!focusedOnInput) {
+					this.flushDebouncer('fireInputChange');
 				}
 			},
 			_decodeHtml: function(html) {


### PR DESCRIPTION
… actions that add/remove levels/criteria from triggering a form submission which causes TinyMCE to fire an unnecessary save event. This can cause a criterion cell to be saved to the wrong cell index. Also removes the need to compare HTML on save.

@wongvincent I discovered that some of the weird behaviour you had been seeing with things saving/rendering inconsistently appears to be mostly caused by a tinymce change event that is triggered as a result of tinymce listening on form submit events.  And when we clicked on buttons like our add/delete level and delete criterion, this was causing a form submit event. 

To work around this I added `type="button"` attributes to a number of the relevant buttons. 

I didn't added it to the Add Criterion or Add Criterion Group buttons as they didn't seem to be causing weird behavior.

I do think there is still the potential for issues if other things cause unexpected save events when the rubric is addding/removing levels/criterion due to the signature of the criterion cell API (being index based). But provided we can avoid those unexpected events I think we'll be good.