### PR TITLE
the html editor toolbars are breaking the drag image for chrome becau…

### DIFF
--- a/editor/d2l-rubric-criteria-editor.html
+++ b/editor/d2l-rubric-criteria-editor.html
@@ -48,10 +48,7 @@
 			}
 
 			.dnd-placeholder::after {
-				/* These margins need to match the width of the left
-				and right gutters to prevent the bottom border being drawn in
-				the gutters */
-				margin: 0 2.5rem 0 2.2rem;
+				margin: 0 var(--d2l-rubric-editor-gutter-width);
 				content: "";
 				position: absolute;
 				top: 0;
@@ -70,10 +67,7 @@
 			}
 
 			.dnd-touch-mirror::after {
-				/* These margins need to match the width of the left
-				and right gutters to prevent the bottom border being drawn in
-				the gutters */
-				margin: 0 2.5rem 0 2.2rem;
+				margin: 0 var(--d2l-rubric-editor-gutter-width);
 				content: "";
 				position: absolute;
 				top: 0;

--- a/editor/d2l-rubric-html-editor.html
+++ b/editor/d2l-rubric-html-editor.html
@@ -63,6 +63,11 @@
 				height: 3.9rem;
 			}
 		}
+
+		[hidden] {
+			display: none;
+		}
+
 	</style>
 	<d2l-html-editor editor-id=[[_uniqueId]]
 					 key=[[key]]
@@ -76,8 +81,10 @@
 					 content=[[_encodeURIComponent(value)]]
 					 toolbar=[[_toolbar]]
 					 plugins=[[_plugins]]
-					 object-resizing=[[objectResizing]]>
-	<div id$="[[_uniqueId]]-toolbar" class="toolbar"></div>
+					 object-resizing=[[objectResizing]]
+					 on-focus="_showToolbar"
+					 on-blur="_hideToolbar">
+	<div id$="[[_uniqueId]]-toolbar" hidden class="toolbar"></div>
 	<div id$="toolbar-shortcut-[[_uniqueId]]" hidden></div>
 	<div class='d2l-richtext-editor-container'
 		id=[[_uniqueId]]
@@ -163,6 +170,12 @@
 			},
 			_encodeURIComponent: function(value) {
 				return value ? encodeURIComponent(value) : '';
+			},
+			_showToolbar: function() {
+				this.$$('.toolbar').removeAttribute('hidden');
+			},
+			_hideToolbar: function() {
+				this.$$('.toolbar').setAttribute('hidden', true);
 			}
 		});
 	</script>


### PR DESCRIPTION
…se they are absolute positioned above the criterion, even when they are not visible. To workaround, explicitly hide/show the toolbar container when the editor is hidden/shown