### PR TITLE
Utilize a rich text editor config entity loaded by the main rurbric e…

### DIFF
--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -70,6 +70,7 @@
 		</div>
 		<d2l-rubric-text-editor
 			id="description"
+			token="[[token]]"
 			key="[[_key]]"
 			aria-invalid="[[_isAriaInvalid(_descriptionInvalid)]]"
 			aria-label="[[_getAriaLabel(ariaLabelLangterm, criterionName, entity.properties)]]"

--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -182,6 +182,13 @@ Creates and edits a rubric
 					if (entity.hasLinkByRel(this.HypermediaRels.Rubrics.overallLevels)) {
 						this._overallLevels = entity.getLinkByRel(this.HypermediaRels.Rubrics.overallLevels) || null;
 					}
+					if (entity.hasSubEntityByRel(this.HypermediaRels.richTextEditorConfig)) {
+						window.D2L.Siren.EntityStore.update(
+							this.HypermediaRels.richTextEditorConfig,
+							this.token,
+							entity.getSubEntityByRel(this.HypermediaRels.richTextEditorConfig)
+						);
+					}
 				}
 			},
 

--- a/editor/d2l-rubric-html-editor.html
+++ b/editor/d2l-rubric-html-editor.html
@@ -154,6 +154,21 @@
 					type: Boolean,
 					value: false,
 				},
+				/**
+				 * The user access token
+				 */
+				token: {
+					type: String,
+				},
+			},
+			attached: function() {
+				this._fetchConfig();
+			},
+			_fetchConfig: function() {
+				var config = window.D2L.Siren.EntityStore.get('https://api.brightspace.com/rels/richtext-editor-config', this.token);
+				if (config) {
+					this.$$('d2l-html-editor').d2lPluginSettings = config.properties;
+				}
 			},
 			focus: function() {
 				this.$$('d2l-html-editor').focus();

--- a/editor/d2l-rubric-html-editor.html
+++ b/editor/d2l-rubric-html-editor.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../../d2l-html-editor/d2l-html-editor-client.html">
 <link rel="import" href="../../d2l-html-editor/d2l-html-editor.html">
 <link rel="import" href="../../d2l-inputs/d2l-input-shared-styles.html">
+<link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 
 <dom-module id="d2l-rubric-html-editor">
 	<template>
@@ -161,11 +162,15 @@
 					type: String,
 				},
 			},
+			behaviors: [
+				window.D2L.Hypermedia.HMConstantsBehavior,
+			],
+
 			attached: function() {
 				this._fetchConfig();
 			},
 			_fetchConfig: function() {
-				var config = window.D2L.Siren.EntityStore.get('https://api.brightspace.com/rels/richtext-editor-config', this.token);
+				var config = window.D2L.Siren.EntityStore.get(this.HypermediaRels.richTextEditorConfig, this.token);
 				if (config) {
 					this.$$('d2l-html-editor').d2lPluginSettings = config.properties;
 				}

--- a/editor/d2l-rubric-text-editor.html
+++ b/editor/d2l-rubric-text-editor.html
@@ -43,6 +43,7 @@
 		<template is="dom-if" if="[[richTextEnabled]]">
 			<d2l-rubric-html-editor
 				id="htmlEditor"
+				token="[[token]]"
 				hidden$=[[!richTextEnabled]]
 				aria-label=[[ariaLabel]]
 				invalid=[[_stringIsTrue(ariaInvalid)]]
@@ -82,7 +83,13 @@
 				disabled: {
 					type: Boolean,
 					value: false,
-				}
+				},
+				/**
+				 * The user access token
+				 */
+				token: {
+					type: String,
+				},
 			},
 			focus: function() {
 				if (this.richTextEnabled) {


### PR DESCRIPTION
…ntity to configure the HTML editor with additional plugin settings, e.g. the endpoint used for launching the Insert Stuff dialog.

Note this depends on:
https://github.com/Brightspace/polymer-siren-behaviors/pull/23
https://github.com/Brightspace/d2l-hm-constants-behavior/pull/73

and cannot be merged until those PR are merged and the versions bumped.