### PR TITLE
Rubric editor header styling cleanup

### DIFF
--- a/editor/d2l-rubric-editor-menu.html
+++ b/editor/d2l-rubric-editor-menu.html
@@ -13,25 +13,26 @@
 				overflow: hidden;
 				padding-top: 0.5rem;
 				padding-bottom: 0.7rem;
-				padding-left: 0.5rem;
-				padding-right: calc( var(--d2l-rubric-editor-gutter-width) - 0.6rem );
 			}
-			:host[is-holistic] {
-				padding-right: calc( var(--d2l-rubric-editor-gutter-width) + 42px );
+
+			.gutter-left {
+				width: 0.5rem;
 			}
+
+			.gutter-right {
+				width: calc( var(--d2l-rubric-editor-gutter-width) - 0.6rem );
+			}
+
+			.gutter-right[holistic] {
+				width: calc( var(--d2l-rubric-editor-gutter-width) + 42px );
+			}
+
 			[hidden] {
 				display: none;
 			}
-			:host(:dir(rtl)) {
-				padding-right: 0.5rem;
-				padding-left: calc( var(--d2l-rubric-editor-gutter-width) - 0.6rem );
-			}
-			:host(:dir(rtl))[is-holistic] {
-				padding-right: 0.5rem;
-				padding-left: calc( var(--d2l-rubric-editor-gutter-width) + 42px );
-			}
 		</style>
 
+		<div class="gutter-left" holistic$="[[isHolistic]]"></div>
 		<d2l-button-subtle hidden$="[[!reverseLevelsEnabled]]"
 			on-tap="_handleReverseTap"
 			icon="d2l-tier1:reverse-order"
@@ -39,6 +40,7 @@
 			type="button"
 		>
 		</d2l-button-subtle>
+		<div class="gutter-right" holistic$="[[isHolistic]]"></div>
 	</template>
 	<script>
 		Polymer({
@@ -51,8 +53,7 @@
 				},
 				isHolistic: {
 					type: Boolean,
-					value: false,
-					reflectToAttribute: true
+					value: false
 				}
 			},
 			behaviors: [

--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -56,6 +56,7 @@ Creates and edits a rubric
 			#rubric-editor-header {
 				display: flex;
 				justify-content: flex-end;
+				flex-wrap: wrap;
 			}
 
 			d2l-dropdown-button-subtle {

--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -266,7 +266,7 @@ Creates and edits a rubric
 			},
 
 			_handleScoringChange: function(e) {
-				if (this._canConvertScoring) {
+				if (this._canConvertScoring && !e.target.selected) {
 					this._disableMenu()
 					var action = this.entity.getActionByName('update-scoring');
 					var fields = [{'name':'scoring-method', 'value':e.target.value}];
@@ -281,10 +281,10 @@ Creates and edits a rubric
 						this._enableMenu();
 					}.bind(this));
 				}
+				Polymer.dom(this.$$('d2l-dropdown-menu')).removeAttribute('opened');
 			},
 
 			_disableMenu: function() {
-				Polymer.dom(this.$$('d2l-dropdown-menu')).removeAttribute('opened');
 				Polymer.dom(this.$$('d2l-dropdown-button-subtle')).setAttribute('disabled','');
 			},
 


### PR DESCRIPTION
Addresses https://trello.com/c/xsYLp0T9/13-rubricsmobile-scoring-and-reverse-level-order-buttons-overlap
and refactors editor-menu to use existing gutters instead of padding.