### PR TITLE
Use action field value when editing descriptions to ensure we are edi…

### DIFF
--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -160,20 +160,31 @@
 				return this.localize(langTerm, 'criterionName', criterionName, 'levelName', levelName);
 			},
 
-			_getDescription: function(entity) {
+			_getDescriptionAction: function(entity) {
+				// Default to 'update' if 'update-description' is not present. Mostly for BG purposes
+				// while the overall levels API is updated to use 'update-description'. Can be removed
+				// later.
+				var action;
 				var description = entity && entity.getSubEntityByClass(this.HypermediaClasses.rubrics.description);
 				if (description) {
-					var action = description.getActionByName('update');
-					if (action) {
-						return action.getFieldByName('description').value;
+					action = description.getActionByName('update-description');
+					if (!action) {
+						action = description.getActionByName('update');
 					}
+				}
+				return action;
+			},
+
+			_getDescription: function(entity) {
+				var action = this._getDescriptionAction(entity);
+				if (action) {
+					return action.getFieldByName('description').value;
 				}
 				return '';
 			},
 
 			_saveDescription: function(e) {
-				var description = this.entity && this.entity.getSubEntityByClass(this.HypermediaClasses.rubrics.description);
-				var action = description.getActionByName('update');
+				var action = this._getDescriptionAction(this.entity);
 				if (action) {
 					this._toggleBubble('_descriptionInvalid', false);
 					var fields = [{'name':'description', 'value':e.detail.value}];
@@ -206,7 +217,7 @@
 			},
 			_computeCanEditDescription: function(entity) {
 				var description = entity && entity.getSubEntityByClass(this.HypermediaClasses.rubrics.description);
-				return description && description.hasActionByName('update');
+				return description && (description.hasActionByName('update-description') || description.hasActionByName('update'));
 			},
 
 			_computeCanEditPoints: function(entity) {

--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -162,7 +162,13 @@
 
 			_getDescription: function(entity) {
 				var description = entity && entity.getSubEntityByClass(this.HypermediaClasses.rubrics.description);
-				return description && description.properties && description.properties.html || '';
+				if (description) {
+					var action = description.getActionByName('update');
+					if (action) {
+						return action.getFieldByName('description').value;
+					}
+				}
+				return '';
 			},
 
 			_saveDescription: function(e) {

--- a/editor/d2l-rubric-html-editor.html
+++ b/editor/d2l-rubric-html-editor.html
@@ -156,7 +156,7 @@
 				},
 				_plugins: {
 					type: String,
-					value: 'lists paste d2l_placeholder d2l_filter d2l_isf',
+					value: 'lists paste d2l_placeholder d2l_filter d2l_isf d2l_replacestring',
 				},
 				objectResizing: {
 					type: Boolean,


### PR DESCRIPTION
…ting the raw HTML rather than the rendered HTML. Otherwise it removes replace strings embedded in the HTML causing them to be saved with their render value.

The `description` rich-text properties contain the render value for the HTML which is pre-processed to make it compatible with render scenarios. This includes transforming replace strings like {OrgUnitName} into their runtime value, and causes `{orgUnitId}` replacement parameters in quick link URLs to be replaced with their runtime value. e.g.
`http://localhost:44444/d2l/common/dialogs/quickLink/quickLink.d2l?ou={orgUnitId}&type=dropbox&rcode=Dev-1`

For HTML editing we need to ensure that the raw HTML is retained/saved.