### PR TITLE
Add aria alerts for validation errors

### DIFF
--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -323,7 +323,7 @@
 				var action = this.entity.getActionByName('update');
 				if (action) {
 					if (this._nameRequired && !e.target.value.trim()) {
-						this._toggleBubble('_nameInvalid', true, this.localize('nameIsRequired'));
+						this._handleValidationError('_nameInvalid', 'nameIsRequired');
 						return;
 					} else {
 						this._toggleBubble('_nameInvalid', false);
@@ -332,7 +332,7 @@
 					this.performSirenAction(action, fields).then(function() {
 						this.fire('d2l-rubric-criterion-saved');
 					}.bind(this)).catch(function() {
-						this._toggleBubble('_nameInvalid', true, this.localize('nameSaveFailed'));
+						this._handleValidationError('_nameInvalid', 'nameSaveFailed');
 					}.bind(this));
 				}
 			},
@@ -341,7 +341,7 @@
 				var action = this.entity.getActionByName('update-outof');
 				if (action) {
 					if (!e.target.value.trim()) {
-						this._toggleBubble('_outOfInvalid', true, this.localize('pointsAreRequired'));
+						this._handleValidationError('_outOfInvalid', 'pointsAreRequired');
 						return;
 					} else {
 						this._toggleBubble('_outOfInvalid', false);
@@ -350,13 +350,19 @@
 					this.performSirenAction(action, fields).then(function() {
 						this.fire('d2l-rubric-criterion-saved');
 					}.bind(this)).catch(function(err) {
-						this._toggleBubble('_outOfInvalid', true, this._getErrMsg(err, 'pointsSaveFailed'));
+						this._handleValidationError('_outOfInvalid', 'pointsSaveFailed', err);
 					}.bind(this));
 				}
 			},
 
+			_handleValidationError: function(property, langterm, error) {
+				var msgText = this._getErrMsg(error, langterm);
+				this._toggleBubble(property, true, msgText);
+				this.fire('iron-announce', { text: msgText }, { bubbles: true });
+			},
+
 			_getErrMsg: function(e, altMsg) {
-				if (!e.hasOwnProperty('stack')) {
+				if (e && !e.hasOwnProperty('stack')) {
 					var errObj = e.string ? e.string : e.json;
 					if (errObj.hasOwnProperty('properties')) {
 						return errObj.properties.detail;

--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -233,6 +233,7 @@
 				if (action) {
 					if (this._pointsRequired && !e.target.value.trim()) {
 						this._toggleBubble('_pointsInvalid', true, this.localize('pointsAreRequired'));
+						this.fire('iron-announce', { text: this.localize('pointsAreRequired') }, { bubbles: true });
 					} else {
 						this._toggleBubble('_pointsInvalid', false);
 						var fields = [{ 'name': 'points', 'value': e.target.value }];
@@ -240,6 +241,7 @@
 							this.fire('d2l-rubric-criterion-cell-points-saved');
 						}.bind(this)).catch(function(err) {
 							this._toggleBubble('_pointsInvalid', true, this._getErrMsg(err, 'pointsSaveFailed'));
+							this.fire('iron-announce', { text: this._getErrMsg(err, 'pointsSaveFailed') }, { bubbles: true });
 						}.bind(this));
 					}
 				}

--- a/editor/d2l-rubric-level-editor.html
+++ b/editor/d2l-rubric-level-editor.html
@@ -220,14 +220,14 @@
 				var action = this.entity.getActionByName('update-name');
 				if (action) {
 					if (this._nameRequired && !e.target.value.trim()) {
-						this._toggleBubble('_nameInvalid', true, this.localize('nameIsRequired'));
+						this._handleValidationError('_nameInvalid', 'nameIsRequired');
 					} else {
 						this._toggleBubble('_nameInvalid', false);
 						var fields = [{'name':'name', 'value':e.target.value}];
 						this.performSirenAction(action, fields).then(function() {
 							this.fire('d2l-rubric-level-saved');
 						}.bind(this)).catch(function(err) {
-							this._toggleBubble('_nameInvalid', true, this._getErrMsg(err, 'nameSaveFailed'));
+							this._handleValidationError('_nameInvalid', 'nameSaveFailed', err);
 						}.bind(this));
 					}
 				}
@@ -237,9 +237,9 @@
 				if (action) {
 					if (this._pointsRequired && !e.target.value.trim()) {
 						if (this._usesPercentage) {
-							this._toggleBubble('_pointsInvalid', true, this.localize('rangeStartRequired'));
+							this._handleValidationError('_pointsInvalid', 'rangeStartRequired');
 						} else {
-							this._toggleBubble('_pointsInvalid', true, this.localize('pointsAreRequired'));
+							this._handleValidationError('_pointsInvalid', 'pointsAreRequired');
 						}
 					} else {
 						this._toggleBubble('_pointsInvalid', false);
@@ -248,16 +248,21 @@
 							this.fire('d2l-rubric-level-points-saved');
 						}.bind(this)).catch(function(err) {
 							if (this._usesPercentage) {
-								this._toggleBubble('_pointsInvalid', true, this._getErrMsg(err, 'rangeStartInvalid'));
+								this._handleValidationError('_pointsInvalid', 'rangeStartInvalid', err);
 							} else {
-								this._toggleBubble('_pointsInvalid', true, this._getErrMsg(err, 'pointsSaveFailed'));
+								this._handleValidationError('_pointsInvalid', 'pointsSaveFailed', err);
 							}
 						}.bind(this));
 					}
 				}
 			},
+			_handleValidationError: function(property, langterm, error) {
+				var msgText = this._getErrMsg(error, langterm);
+				this._toggleBubble(property, true, msgText);
+				this.fire('iron-announce', { text: msgText }, { bubbles: true });
+			},
 			_getErrMsg: function(e, altMsg) {
-				if (!e.hasOwnProperty('stack')) {
+				if (e && !e.hasOwnProperty('stack')) {
 					var errObj = e.string ? e.string : e.json;
 					if (errObj.hasOwnProperty('properties')) {
 						return errObj.properties.detail;

--- a/editor/d2l-rubric-overall-level-editor.html
+++ b/editor/d2l-rubric-overall-level-editor.html
@@ -184,14 +184,14 @@
 				var action = this.entity.getActionByName('update-name');
 				if (action) {
 					if (this._nameRequired && !e.target.value.trim()) {
-						this._handleValidationError('_nameInvalid', 'nameIsRequired')
+						this._handleValidationError('_nameInvalid', 'nameIsRequired');
 					} else {
 						this._toggleBubble('_nameInvalid', false);
 						var fields = [{ 'name': 'name', 'value': e.target.value }];
 						this.performSirenAction(action, fields).then(function() {
 							this.fire('d2l-rubric-overall-level-saved');
 						}.bind(this)).catch(function() {
-							this._handleValidationError('_nameInvalid', 'nameSaveFailed')
+							this._handleValidationError('_nameInvalid', 'nameSaveFailed');
 						}.bind(this));
 					}
 				}
@@ -200,14 +200,14 @@
 				var action = this.entity.getActionByName('update-range-start');
 				if (action) {
 					if (this._rangeStartRequired && !e.target.value.trim()) {
-						this._handleValidationError('_rangeStartInvalid', 'rangeStartRequired')
+						this._handleValidationError('_rangeStartInvalid', 'rangeStartRequired');
 					} else {
 						this._toggleBubble('_rangeStartInvalid', false);
 						var fields = [{'name':'rangeStart', 'value':e.target.value}];
 						this.performSirenAction(action, fields).then(function() {
 							this.fire('d2l-rubric-overall-level-range-start-saved');
 						}.bind(this)).catch(function(e) {
-							this._handleValidationError('_rangeStartInvalid', 'rangeStartInvalid', e)
+							this._handleValidationError('_rangeStartInvalid', 'rangeStartInvalid', e);
 						}.bind(this));
 					}
 				}
@@ -224,7 +224,6 @@
 						return errObj.properties.detail;
 					}
 				}
-				console.log("Alt: " + altMsg);
 				return this.localize(altMsg);
 			},
 			_toggleBubble: function(invalidId, show, error) {

--- a/editor/d2l-rubric-overall-level-editor.html
+++ b/editor/d2l-rubric-overall-level-editor.html
@@ -153,7 +153,7 @@
 				return entity && entity.hasProperty('rangeStart') && entity.properties.rangeStart !== null;
 			},
 			_isRangeStartRequired: function(entity) {
-				var action = entity && entity.getActionByName('update');
+				var action = entity && entity.getActionByName('update-range-start');
 				if (!action) {
 					return false;
 				}
@@ -184,14 +184,14 @@
 				var action = this.entity.getActionByName('update-name');
 				if (action) {
 					if (this._nameRequired && !e.target.value.trim()) {
-						this._toggleBubble('_nameInvalid', true, this.localize('nameIsRequired'));
+						this._handleValidationError('_nameInvalid', 'nameIsRequired')
 					} else {
 						this._toggleBubble('_nameInvalid', false);
 						var fields = [{ 'name': 'name', 'value': e.target.value }];
 						this.performSirenAction(action, fields).then(function() {
 							this.fire('d2l-rubric-overall-level-saved');
 						}.bind(this)).catch(function() {
-							this._toggleBubble('_nameInvalid', true, this.localize('nameSaveFailed'));
+							this._handleValidationError('_nameInvalid', 'nameSaveFailed')
 						}.bind(this));
 					}
 				}
@@ -200,22 +200,32 @@
 				var action = this.entity.getActionByName('update-range-start');
 				if (action) {
 					if (this._rangeStartRequired && !e.target.value.trim()) {
-						this._toggleBubble('_rangeStartInvalid', true, this.localize('rangeStartRequired'));
+						this._handleValidationError('_rangeStartInvalid', 'rangeStartRequired')
 					} else {
 						this._toggleBubble('_rangeStartInvalid', false);
 						var fields = [{'name':'rangeStart', 'value':e.target.value}];
 						this.performSirenAction(action, fields).then(function() {
 							this.fire('d2l-rubric-overall-level-range-start-saved');
 						}.bind(this)).catch(function(e) {
-							if (!e.json) {
-								this._toggleBubble('_rangeStartInvalid', true, this.localize('rangeStartInvalid'));
-							} else {
-								this._toggleBubble('_rangeStartInvalid', true, e.json.properties.detail);
-							}
-
+							this._handleValidationError('_rangeStartInvalid', 'rangeStartInvalid', e)
 						}.bind(this));
 					}
 				}
+			},
+			_handleValidationError: function(property, langterm, error) {
+				var msgText = this._getErrMsg(error, langterm);
+				this._toggleBubble(property, true, msgText);
+				this.fire('iron-announce', { text: msgText }, { bubbles: true });
+			},
+			_getErrMsg: function(e, altMsg) {
+				if (e && !e.hasOwnProperty('stack')) {
+					var errObj = e.string ? e.string : e.json;
+					if (errObj.hasOwnProperty('properties')) {
+						return errObj.properties.detail;
+					}
+				}
+				console.log("Alt: " + altMsg);
+				return this.localize(altMsg);
 			},
 			_toggleBubble: function(invalidId, show, error) {
 				if (show) {


### PR DESCRIPTION
Addresses https://trello.com/c/hQPZZ7pI/20-a11y-add-an-aria-alert-on-validation-error

Previously there was no a11y handling of validation errors. Now when validation of a field fails, it will be announced using `iron-announce` with the same lang term as the tool-tip.

For components with more than 2 validation error handling locations, I added a dedicated `_handleValidationError` to toggle the error tool-tip and make the announcement.

(Also found and fixed a small bug in the overall levels, where the name of the `update-range-start` action had not been updated, so the required property was not being set correctly).