### PR TITLE
fixes alignment problem on mobile of header

### DIFF
--- a/editor/d2l-rubric-editor-menu.html
+++ b/editor/d2l-rubric-editor-menu.html
@@ -11,7 +11,7 @@
 				flex-direction: row;
 				justify-content: flex-end;
 				overflow: hidden;
-				padding-top: 0.5rem;
+				margin-top: 0.5rem;
 				padding-bottom: 0.7rem;
 			}
 
@@ -19,20 +19,12 @@
 				width: 0.5rem;
 			}
 
-			.gutter-right {
-				width: calc( var(--d2l-rubric-editor-gutter-width) - 0.6rem );
-			}
-
-			.gutter-right[holistic] {
-				width: calc( var(--d2l-rubric-editor-gutter-width) + 42px );
-			}
-
 			[hidden] {
 				display: none;
 			}
 		</style>
 
-		<div class="gutter-left" holistic$="[[isHolistic]]"></div>
+		<div class="gutter-left"></div>
 		<d2l-button-subtle hidden$="[[!reverseLevelsEnabled]]"
 			on-tap="_handleReverseTap"
 			icon="d2l-tier1:reverse-order"
@@ -40,7 +32,6 @@
 			type="button"
 		>
 		</d2l-button-subtle>
-		<div class="gutter-right" holistic$="[[isHolistic]]"></div>
 	</template>
 	<script>
 		Polymer({
@@ -48,10 +39,6 @@
 
 			properties: {
 				reverseLevelsEnabled: {
-					type: Boolean,
-					value: false
-				},
-				isHolistic: {
 					type: Boolean,
 					value: false
 				}

--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -53,10 +53,15 @@ Creates and edits a rubric
 				padding-left: 46px;
 			}
 
-			#rubric-editor-header {
+			#rubric-editor-header-content {
 				display: flex;
 				justify-content: flex-end;
 				flex-wrap: wrap;
+			}
+
+			#rubric-editor-header {
+				display: flex;
+				justify-content: flex-end;
 			}
 
 			d2l-dropdown-button-subtle {
@@ -65,6 +70,14 @@ Creates and edits a rubric
 
 			d2l-alert {
 				margin: 0 var(--d2l-rubric-editor-gutter-width);
+			}
+
+			.gutter-right {
+				width: calc( var(--d2l-rubric-editor-gutter-width) - 0.6rem );
+			}
+
+			.gutter-right[holistic] {
+				width: calc( var(--d2l-rubric-editor-gutter-width) + 42px );
 			}
 
 			/* temporary spacing to stop UI shifting down on first save, until single-page rubric creation is implemented */
@@ -91,17 +104,19 @@ Creates and edits a rubric
 		</div>
 		<div id="rubric-editor-container" hidden >
 			<div id="rubric-editor-header">
-				<d2l-dropdown-button-subtle text="[[_scoringText]]" hidden$="[[!_canConvertScoring]]">
-					<d2l-dropdown-menu id="dropdown">
-						<d2l-menu label="Scoring"></d2l-menu>
-					</d2l-dropdown-menu>
-				</d2l-dropdown-button-subtle>
+				<div id="rubric-editor-header-content">
+					<d2l-dropdown-button-subtle text="[[_scoringText]]" hidden$="[[!_canConvertScoring]]">
+						<d2l-dropdown-menu id="dropdown">
+							<d2l-menu label="Scoring"></d2l-menu>
+						</d2l-dropdown-menu>
+					</d2l-dropdown-button-subtle>
 
-				<d2l-rubric-editor-menu
-					on-d2l-rubric-reverse-levels="_handleReverseLevels"
-					reverse-levels-enabled="[[_present(_reverseLevels)]]"
-					is-holistic="[[_isHolistic]]">
-				</d2l-rubric-editor-menu>
+					<d2l-rubric-editor-menu
+						on-d2l-rubric-reverse-levels="_handleReverseLevels"
+						reverse-levels-enabled="[[_present(_reverseLevels)]]">
+					</d2l-rubric-editor-menu>
+				</div>
+				<div class="gutter-right" holistic$="[[_isHolistic]]"></div>
 			</div>
 
 			<d2l-rubric-criteria-groups-editor


### PR DESCRIPTION
Fixes https://trello.com/c/MdgGZqb3/22-mobile-android-and-iphone-portrait-view-scoring-and-reverse-buttons-look-messy by putting the right gutter after a block surrounding the two header components instead of after the last component of the header.