### PR TITLE
US101449 - Add Rubric Status dropdown and call API on change

### DIFF
--- a/editor/d2l-rubric-structure-editor.html
+++ b/editor/d2l-rubric-structure-editor.html
@@ -15,6 +15,8 @@
 <link rel="import" href="../../iron-a11y-announcer/iron-a11y-announcer.html">
 <link rel="import" href="../../d2l-menu/d2l-menu-item-radio.html">
 <link rel="import" href="./d2l-rubric-dialog-behavior.html">
+<link rel="import" href="../../d2l-dropdown/d2l-dropdown-button-subtle.html">
+<link rel="import" href="../../d2l-dropdown/d2l-dropdown-menu.html">
 
 <!--
 `d2l-rubric-structure-editor`
@@ -60,26 +62,26 @@ Creates and edits a rubric structue
 				margin-left: calc(var(--d2l-rubric-editor-gutter-width));
 			}
 
-			#header-start-container > * {
+			#header-start-container > *, #header-end-container > * {
 				margin: 0.75rem 0.3rem;
 			}
 
-			#header-start-container > *:first-child {
+			#header-start-container > *:first-child, #header-end-container > *:first-child {
 				margin-left: unset;
 				margin-right: 0.3rem;
 			}
 
-			#header-start-container > *:last-child {
+			#header-start-container > *:last-child, #header-end-container > *:last-child {
 				margin-left: 0.3rem;
 				margin-right: unset;
 			}
 
-			:dir(rtl) #header-start-container > *:first-child {
+			:dir(rtl) #header-start-container > *:first-child, #header-end-container > *:first-child {
 				margin-left: 0.3rem;
 				margin-right: unset;
 			}
 
-			:dir(rtl) #header-start-container > *:last-child {
+			:dir(rtl) #header-start-container > *:last-child, #header-end-container > *:last-child {
 				margin-left: unset;
 				margin-right: 0.3rem;
 			}
@@ -101,6 +103,10 @@ Creates and edits a rubric structue
 
 			.gutter-right[holistic] {
 				width: calc( var(--d2l-rubric-editor-gutter-width) + 42px );
+			}
+
+			#editor-save-status {
+				display: inline-block;
 			}
 
 			[hidden] {
@@ -141,6 +147,11 @@ Creates and edits a rubric structue
 				</div>
 				<div id="header-end-container">
 					<d2l-save-status id="editor-save-status"></d2l-save-status>
+					<d2l-dropdown-button-subtle text="[[_rubricStatusText]]" hidden$="[[!_canChangeStatus]]" on-d2l-menu-item-change="_handleStatusChange">
+						<d2l-dropdown-menu>
+							<d2l-menu id="status-menu" label="Status"></d2l-menu>
+						</d2l-dropdown-menu>
+					</d2l-dropdown-button-subtle>
 				</div>
 			</div>
 			<div class="gutter-right" holistic$="[[_isHolistic]]"></div>
@@ -226,6 +237,18 @@ Creates and edits a rubric structue
 					type: String,
 					value: null
 				},
+				_canChangeStatus: {
+					type: Boolean,
+					value: false
+				},
+				_rubricStatusText: {
+					type: String,
+					value: null
+				},
+				_rubricStatus: {
+					type: String,
+					value: null
+				}
 			},
 
 			behaviors: [
@@ -315,6 +338,21 @@ Creates and edits a rubric structue
 							}
 						}
 						this._canConvertType = true;
+					}
+
+					if (entity.hasActionByName('update-status')) {
+						var options = entity.getActionByName('update-status')
+							.getFieldByName('rubric-status').value || [];
+
+						//Only re-populate the menu if _canChangeStatus was previously null/undefined or false
+						if (!this._canChangeStatus) {
+							var selected = this._populateDropdownMenuOptions('status-menu', options);
+							if (selected) {
+								this._rubricStatus = selected.value;
+								this._rubricStatusText = this.localize('rubricStatus', 'status', selected.title);
+							}
+						}
+						this._canChangeStatus = true;
 					}
 				}
 			},
@@ -444,7 +482,7 @@ Creates and edits a rubric structue
 				var items = Polymer.dom(menuButton).querySelectorAll('d2l-menu-item-radio');
 				for (var i = 0; i < items.length; i++) {
 					if (items[i].value === optionValue) {
-						items[i].setAttribute('selected','');
+						items[i].setAttribute('selected', '');
 					} else {
 						items[i].removeAttribute('selected');
 					}
@@ -469,9 +507,32 @@ Creates and edits a rubric structue
 						selected = option;
 						Polymer.dom(item).setAttribute('selected', '');
 					}
-					Polymer.dom(menu).appendChild(item)
+					Polymer.dom(menu).appendChild(item);
 				}
 				return selected;
+			},
+
+			_handleStatusChange: function(e) {
+				var menuButton = e.currentTarget;
+				var dropdownMenu = Polymer.dom(menuButton).querySelector('d2l-dropdown-menu');
+				if (!this._canChangeStatus || e.target.value === this._rubricStatus) return;
+
+				Polymer.dom(dropdownMenu).removeAttribute('opened');
+				this._disableMenu(menuButton);
+
+				var action = this.entity.getActionByName('update-status');
+				var fields = [{'name':'status', 'value':e.target.value}];
+				this.performSirenAction(action, fields).then(function() {
+					this._rubricStatusText = this.localize('rubricStatus', 'status', e.target.text);
+					this._rubricStatus = e.target.value;
+					this.fire('d2l-rubric-status-changed');
+					this.fire('iron-announce', { text: this.localize('changeRubricStatusSuccessful', 'status', e.target.text) }, { bubbles: true });
+				}.bind(this)).then(function() {
+					this._enableMenu(menuButton);
+				}.bind(this)).catch(function() {
+					this._resetSelectedMenuItem(menuButton, this._rubricStatus);
+					this._enableMenu(menuButton);
+				}.bind(this));
 			}
 		});
 	</script>

--- a/lang/en.html
+++ b/lang/en.html
@@ -103,7 +103,9 @@
 			'changeConfirmationYes': 'Continue',
 			'changeConfirmationNo': 'Cancel',
 			'changeRubricTypeWarnTitle': 'Change rubric type?',
-			'changeRubricTypeWarnMessage': 'Changing your rubric from analytic to holistic may result in data loss.'
+			'changeRubricTypeWarnMessage': 'Changing your rubric from analytic to holistic may result in data loss.',
+			'rubricStatus': 'Status: {status}',
+			'changeRubricStatusSuccessful': 'Rubric status changed to {status}',
 		}
 	};
 </script>


### PR DESCRIPTION
I swapped the `save-status` and Status dropdown order so that the dropdown doesn't shift when the save-status message pops in. Still awaiting the final design for that, but will merge this when it's ready