### PR TITLE
Remove IE and Edge from test browsers

### DIFF
--- a/modify_wct_sauce_config.js
+++ b/modify_wct_sauce_config.js
@@ -51,7 +51,7 @@ var platform_array =  [
       "browserName": "safari",
       "platform": "OS X 10.13",
       "version": ""
-    },
+	}/*,
     {
       "browserName": "microsoftedge",
       "platform": "Windows 10",
@@ -61,7 +61,7 @@ var platform_array =  [
       "browserName": "internet explorer",
       "platform": "Windows 10",
       "version": ""
-    }
+    }*/
   ]
 
 //add two random platforms to the json


### PR DESCRIPTION
Since IE and Edge tests always fail, and we have to re-run the build, this does not help us so I removed these from the list of browsers for CI tests to randomly choose from.