### PR TITLE
fix error tooltip not showing up

### DIFF
--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -51,6 +51,7 @@ Creates and edits a rubric
 				value="[[_rubricName]]"
 				on-change="_saveName"
 				aria-invalid="[[isAriaInvalid(_nameInvalid)]]"
+				aria-label="[[localize('name')]]"
 				disabled="[[!_canEditName]]"
 				prevent-submit
 			>

--- a/editor/d2l-rubric-error-handling-behavior.html
+++ b/editor/d2l-rubric-error-handling-behavior.html
@@ -29,7 +29,7 @@
 			if (e && !e.hasOwnProperty('stack')) {
 				var errObj = e.string ? e.string : e.json;
 				if (errObj.hasOwnProperty('properties')) {
-					return errObj.properties.detail;
+					return errObj.properties.detail || errObj.properties.errors[0].message || this.localize(altMsg);
 				}
 			}
 			return this.localize(altMsg);


### PR DESCRIPTION
Fixes https://trello.com/c/dz0y8mi2/51-rubrics-name-field-does-not-show-error-tool-tip-for-too-long-names-and-does-not-have-aria-label-axe-violation