### PR TITLE
Align rubric-editor error alerts, and associate description field tooltip correctly

### DIFF
--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -78,6 +78,10 @@ Creates and edits a rubric
 				margin-right: 0.3rem;
 			}
 
+			d2l-alert {
+				margin: 0 var(--d2l-rubric-editor-gutter-width);
+			}
+
 		</style>
 		<d2l-rubric-editor-header
 			id="rubric-header">
@@ -141,7 +145,7 @@ Creates and edits a rubric
 						>
 						</d2l-rubric-text-editor>
 						<template is="dom-if" if="[[_descriptionInvalid]]">
-							<d2l-tooltip for="description" position="bottom">[[_descriptionInvalidError]]</d2l-tooltip>
+							<d2l-tooltip for="rubric-description" position="bottom">[[_descriptionInvalidError]]</d2l-tooltip>
 						</template>
 					</div>
 					<div id="hide-score-container">


### PR DESCRIPTION
Fixes 2 small issues I found while testing the new spe header and description:
- in the header, the alert popups were not aligned with the rubric, so I added the gutter
- the description field error tooltip was associated with the id `description`, but the element actually has the id `rubric-description`
