### PR TITLE
Hide button in Chrome with shadow-dom enabled

### DIFF
--- a/editor/d2l-rubric-criteria-editor.html
+++ b/editor/d2l-rubric-criteria-editor.html
@@ -129,8 +129,8 @@
 			d2l-rubric-criterion-editor {
 				flex: 1 1 auto;
 			}
-			.force-hidden {
-				display:none !important;
+			.force-hidden, [hidden] {
+				display: none !important;
 			}
 		</style>
 		<div>


### PR DESCRIPTION
Addresses https://trello.com/c/LTe0ZYu8/8-rubricsshadow-domchrome-add-criterion-button-not-hidden-on-holistic-rubric
Force hide the element when hidden, as one of the underlying style sheets is likely overriding it.