### PR TITLE
pass updateAssociations param when updating associations.

### DIFF
--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -495,6 +495,7 @@ Creates and edits a rubric
 						value: check.value
 					}
 				});
+				fields.push({'name':'updateAssociations', 'value':true});
 				this.performSirenAction(action, fields).then(function() {
 					this.fire('d2l-rubric-associations-saved');
 				}.bind(this)).catch(function(err) {


### PR DESCRIPTION
Goes with https://git.dev.d2l/projects/CORE/repos/lp/pull-requests/11775/overview to fix 
https://trello.com/c/csuF2VfR/13-rubrics-single-page-when-you-create-a-new-rubric-or-edit-existing-rubric-and-change-the-name-associations-get-unchecked