### PR TITLE
add support for html editing to criterion feedback

### DIFF
--- a/editor/d2l-input-radio-styles.html
+++ b/editor/d2l-input-radio-styles.html
@@ -6,7 +6,7 @@
 'd2l-input-radio-styles'
 Styles for radio button
 
-@demo demo/d2l-input-radio-rubric.html
+@demo demo/d2l-input-radio-styles.html
 -->
 
 <dom-module id="d2l-input-radio-styles">
@@ -21,6 +21,12 @@ Styles for radio button
 				@apply --d2l-body-compact-text;
 				color: var(--d2l-color-ferrite);
 				margin-bottom: 0.9rem;
+			}
+			.d2l-input-radio-label.disabled {
+				opacity: 0.5;
+			}
+			.d2l-input-radio-label.disabled > input[type="radio"] {
+				opacity: 1.0;
 			}
 			.d2l-input-radio-label:last-of-type {
 				margin-bottom: 0;

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -199,10 +199,12 @@
 				<template is="dom-repeat" as="criterionCell" items="[[_getCriterionCells(entity)]]">
 					<div class="cell">
 						<d2l-rubric-feedback-editor
+							key-link-rels="[[_getCellKeyRels()]]"
 							href="[[_getSelfLink(criterionCell)]]"
 							token="[[token]]"
 							aria-label-langterm="criterionFeedbackAriaLabel"
 							criterion-name="[[entity.properties.name]]"
+							rich-text-enabled="[[richTextEnabled]]"
 						>
 						</d2l-rubric-feedback-editor>
 					</div>

--- a/editor/d2l-rubric-feedback-editor.html
+++ b/editor/d2l-rubric-feedback-editor.html
@@ -1,11 +1,11 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
-<link rel="import" href="../../d2l-inputs/d2l-input-textarea.html">
 <link rel="import" href="../../d2l-tooltip/d2l-tooltip.html">
 
 <link rel="import" href="../d2l-rubric-entity-behavior.html">
 <link rel="import" href="../../d2l-polymer-siren-behaviors/store/siren-action-behavior.html">
 <link rel="import" href="./../localize-behavior.html">
+<link rel="import" href="./d2l-rubric-text-editor.html">
 <link rel="import" href="./d2l-rubric-error-handling-behavior.html">
 
 <dom-module id="d2l-rubric-feedback-editor">
@@ -19,6 +19,10 @@
 					min-height: 0;
 					overflow: hidden;
 					hyphens: auto;
+					border-color: transparent;
+					box-shadow: none;
+					border-radius: 0;
+					transition-property: none;
 				};
 			}
 
@@ -26,18 +30,22 @@
 				box-sizing: border-box;
 			}
 
-		</style>
+			d2l-rubric-text-editor {
+				flex-grow: 1;
+			}
 
-		<d2l-input-textarea
+		</style>
+		<d2l-rubric-text-editor
 			id="feedback"
+			token="[[token]]"
+			key="[[_key]]"
 			aria-invalid="[[isAriaInvalid(_feedbackInvalid)]]"
 			aria-label="[[_getAriaLabel(ariaLabelLangterm, criterionName, entity.properties)]]"
 			disabled="[[!_canEdit]]"
-			no-border
-			hover-styles
 			value=[[_getFeedback(entity)]]
 			on-change="_saveFeedback"
-		></d2l-input-textarea>
+			rich-text-enabled="[[_richTextAndEditEnabled(richTextEnabled,_canEdit)]]"
+		>
 		<template is="dom-if" if="[[_feedbackInvalid]]">
 			<d2l-tooltip for="feedback" position="bottom">[[_feedbackInvalidError]]</d2l-tooltip>
 		</template>
@@ -70,6 +78,14 @@
 				_feedbackInvalidError: {
 					type: String
 				},
+				keyLinkRels: {
+					type: Array,
+					value: function() { return ['self']; }
+				},
+				_key: {
+					type: String,
+					computed: '_constructKey(keyLinkRels, entity)',
+				},
 			},
 
 			behaviors: [
@@ -86,21 +102,32 @@
 			},
 
 			_getFeedback: function(entity) {
+				var action = this._getFeedbackAction(entity);
+				if (action) {
+					return action.getFieldByName('feedback').value;
+				}
+				return '';
+			},
+
+			_getFeedbackAction: function(entity) {
+				var action;
 				var feedback = entity && entity.getSubEntityByClass(this.HypermediaClasses.rubrics.feedback);
-				return feedback && feedback.properties && feedback.properties.text || '';
+				if (feedback) {
+					action = feedback.getActionByName('update-feedback');
+				}
+				return action;
 			},
 
 			_canEditFeedback: function(entity) {
 				var feedback = entity && entity.getSubEntityByClass(this.HypermediaClasses.rubrics.feedback);
-				return feedback && feedback.hasActionByName('update');
+				return feedback && feedback.hasActionByName('update-feedback');
 			},
 
 			_saveFeedback: function(e) {
-				var feedback = this.entity && this.entity.getSubEntityByClass(this.HypermediaClasses.rubrics.feedback);
-				var action = feedback.getActionByName('update');
+				var action = this._getFeedbackAction(this.entity);
 				if (action) {
 					this.toggleBubble('_feedbackInvalid', false);
-					var fields = [{'name':'feedback', 'value':e.target.value}];
+					var fields = [{'name':'feedback', 'value':e.detail.value}];
 					this.performSirenAction(action, fields).then(function() {
 						this.fire('d2l-rubric-feedback-saved');
 					}.bind(this)).catch(function() {
@@ -108,6 +135,23 @@
 					}.bind(this));
 				}
 			},
+
+			_constructKey: function(keyLinkRels, entity) {
+				var constructed = '';
+				if (entity && entity.hasLinkByRel) {
+					keyLinkRels.forEach(function(rel) {
+						if (entity.hasLinkByRel(rel)) {
+							constructed += entity.getLinkByRel(rel).href;
+							constructed += '|';
+						}
+					});
+				}
+				return constructed;
+			},
+
+			_richTextAndEditEnabled: function(richTextEnabled, canEditDescription) {
+				return richTextEnabled && canEditDescription;
+			}
 
 		});
 	</script>

--- a/test/components/d2l-rubric-feedback-editor.js
+++ b/test/components/d2l-rubric-feedback-editor.js
@@ -43,6 +43,7 @@ suite('<d2l-rubric-feedback-editor>', function() {
 
 				teardown(function() {
 					fetch && fetch.restore();
+					window.D2L.Siren.EntityStore.clear();
 				});
 
 				test('saves feedback', function(done) {
@@ -55,7 +56,7 @@ suite('<d2l-rubric-feedback-editor>', function() {
 					});
 					fetch.returns(promise);
 
-					var feedbackTextArea = element.$$('d2l-input-textarea');
+					var feedbackTextArea = element.$$('d2l-rubric-text-editor');
 					feedbackTextArea.value = 'You are a grammar rockstar!';
 					raf(function() {
 						element.addEventListener('d2l-rubric-feedback-saved', function() {
@@ -64,7 +65,7 @@ suite('<d2l-rubric-feedback-editor>', function() {
 							expect(body.get && body.get('feedback') || 'You are a grammar rockstar!').to.equal('You are a grammar rockstar!');
 							done();
 						});
-						feedbackTextArea.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: false, composed: true }));
+						feedbackTextArea.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: false, composed: true, detail: {value: feedbackTextArea.value} }));
 					});
 				});
 
@@ -78,7 +79,7 @@ suite('<d2l-rubric-feedback-editor>', function() {
 					});
 					fetch.returns(promise);
 
-					var feedbackTextArea = element.$$('d2l-input-textarea');
+					var feedbackTextArea = element.$$('d2l-rubric-text-editor');
 					feedbackTextArea.value = 'You are a grammar rockstar!';
 					raf(function() {
 						element.addEventListener('d2l-siren-entity-save-error', function() {
@@ -90,7 +91,7 @@ suite('<d2l-rubric-feedback-editor>', function() {
 								done();
 							});
 						});
-						feedbackTextArea.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: false, composed: true }));
+						feedbackTextArea.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: false, composed: true, detail: {value: feedbackTextArea.value} }));
 					});
 				});
 			});
@@ -112,108 +113,7 @@ suite('<d2l-rubric-feedback-editor>', function() {
 				});
 
 				test('feedback is disabled', function() {
-					var feedbackTextArea = element.$$('d2l-input-textarea');
-					expect(feedbackTextArea.disabled).to.be.true;
-				});
-
-			});
-		});
-		suite('overall level description', function() {
-			test('can be instantiated', function() {
-				var element = fixture('basic-overall-level');
-				expect(element.is).to.equal('d2l-rubric-feedback-editor');
-			});
-
-			suite('edit feedback', function() {
-
-				var fetch;
-				var raf = window.requestAnimationFrame;
-				var element;
-
-				setup(function(done) {
-					element = fixture('basic-overall-level');
-					function waitForLoad(e) {
-						if (e.detail.entity.getLinkByRel('self').href === 'static-data/rubrics/organizations/text-only/199/overall-levels/1.json') {
-							element.removeEventListener('d2l-siren-entity-changed', waitForLoad);
-							done();
-						}
-					}
-					element.addEventListener('d2l-siren-entity-changed', waitForLoad);
-					element.token = 'foozleberries';
-				});
-
-				teardown(function() {
-					fetch && fetch.restore();
-				});
-
-				test('saves feedback', function(done) {
-					fetch = sinon.stub(window.d2lfetch, 'fetch');
-					var promise = Promise.resolve({
-						ok: true,
-						json: function() {
-							return Promise.resolve(JSON.stringify(window.testFixtures.overall_level_feedback_mod));
-						}
-					});
-					fetch.returns(promise);
-
-					var feedbackTextArea = element.$$('d2l-input-textarea');
-					feedbackTextArea.value = 'You are a grammar rockstar!';
-					raf(function() {
-						element.addEventListener('d2l-rubric-feedback-saved', function() {
-							var body = fetch.args[0][1].body;
-							// Force success in IE - no FormData op support
-							expect(body.get && body.get('feedback') || 'You are a grammar rockstar!').to.equal('You are a grammar rockstar!');
-							done();
-						});
-						feedbackTextArea.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: false, composed: true }));
-					});
-				});
-
-				test('sets aria-invalid if saving feedback fails', function(done) {
-					fetch = sinon.stub(window.d2lfetch, 'fetch');
-					var promise = Promise.resolve({
-						ok: false,
-						json: function() {
-							return Promise.resolve(JSON.stringify({}));
-						}
-					});
-					fetch.returns(promise);
-
-					var feedbackTextArea = element.$$('d2l-input-textarea');
-					feedbackTextArea.value = 'You are a grammar rockstar!';
-					raf(function() {
-						element.addEventListener('d2l-siren-entity-save-error', function() {
-							flush(function() {
-								// don't test in IE
-								if (!isIE) {
-									expect(feedbackTextArea.ariaInvalid).to.equal('true');
-								}
-								done();
-							});
-						});
-						feedbackTextArea.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: false, composed: true }));
-					});
-				});
-			});
-
-			suite('readonly', function() {
-
-				var element;
-
-				setup(function(done) {
-					element = fixture('readonly-overall-level');
-					function waitForLoad(e) {
-						if (e.detail.entity.getLinkByRel('self').href === 'static-data/rubrics/organizations/text-only/199/overall-levels/2.json') {
-							element.removeEventListener('d2l-siren-entity-changed', waitForLoad);
-							done();
-						}
-					}
-					element.addEventListener('d2l-siren-entity-changed', waitForLoad);
-					element.token = 'foozleberries';
-				});
-
-				test('feedback is disabled', function() {
-					var feedbackTextArea = element.$$('d2l-input-textarea');
+					var feedbackTextArea = element.$$('d2l-rubric-text-editor');
 					expect(feedbackTextArea.disabled).to.be.true;
 				});
 

--- a/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json
+++ b/test/components/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json
@@ -52,15 +52,10 @@
             },
             "actions": [
               {
-                "name": "update",
-                "method": "PUT",
+                "name": "update-feedback",
+                "method": "PATCH",
                 "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json",
                 "fields": [
-                  {
-                    "type": "hidden",
-                    "name": "description",
-                    "value": "Proper use of grammar"
-                  },
                   {
                     "type": "text",
                     "name": "feedback",


### PR DESCRIPTION
Added support for HTML to feedback.
Some stylings and handling probably ripe for refactor - next time - copy twice, wince; copy three times refactor...

Also removed some old tests for handling feedback in overall levels which we no longer support.