### PR TITLE
fix help link text size

### DIFF
--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -306,8 +306,8 @@ Creates and edits a rubric
 								<d2l-tooltip for="associations" position="bottom">[[_associationsInvalidError]]</d2l-tooltip>
 							</template>
 						</fieldset>
-						<div class="help-link">
-							<d2l-link small on-click="_openHelpDialog">[[localize('helpAssociations')]]</d2l-link>
+						<div class="help-link d2l-body-compact">
+							<d2l-link on-click="_openHelpDialog">[[localize('helpAssociations')]]</d2l-link>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
Fixes https://trello.com/c/SiF879ZW/14-rubric-associations-help-link-text-is-too-small