### PR TITLE
Align error handling

### DIFF
--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -256,6 +256,8 @@
 						var fields = [{'name': 'name', 'value':e.target.value}];
 						this.performSirenAction(action, fields).then(function() {
 							this.fire('d2l-rubric-group-name-saved');
+						}.bind(this)).catch(function(err) {
+							this.handleValidationError('_nameInvalid', 'groupNameSaveFailed', err);
 						}.bind(this));
 					}
 				}

--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -203,7 +203,7 @@
 					this.performSirenAction(action, fields).then(function() {
 						this.fire('d2l-rubric-description-saved');
 					}.bind(this)).catch(function(err) {
-						this.toggleBubble('_descriptionInvalid', true, this.getErrMsg(err, 'descriptionSaveFailed'));
+						this.handleValidationError('_descriptionInvalid', 'descriptionSaveFailed', err);
 					}.bind(this));
 				}
 			},
@@ -243,8 +243,7 @@
 						this.performSirenAction(action, fields).then(function() {
 							this.fire('d2l-rubric-criterion-cell-points-saved');
 						}.bind(this)).catch(function(err) {
-							this.toggleBubble('_pointsInvalid', true, this.getErrMsg(err, 'pointsSaveFailed'));
-							this.fire('iron-announce', { text: this.getErrMsg(err, 'pointsSaveFailed') }, { bubbles: true });
+							this.handleValidationError('_pointsInvalid', 'pointsSaveFailed', err);
 						}.bind(this));
 					}
 				}

--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -616,7 +616,7 @@ Creates and edits a rubric
 					this.performSirenAction(action, fields).then(function() {
 						this.fire('d2l-rubric-description-saved');
 					}.bind(this)).catch(function(err) {
-						this.toggleBubble('_descriptionInvalid', true, this.getErrMsg(err, 'descriptionSaveFailed'));
+						this.handleValidationError('_descriptionInvalid', 'descriptionSaveFailed', err);
 					}.bind(this));
 				}
 			},
@@ -650,7 +650,7 @@ Creates and edits a rubric
 						checkbox.checked = !checkbox.checked;
 						checkbox.style.borderColor = '#cd2026';
 						checkbox.disabled = false;
-						this.toggleBubble('_setScoreVisibilityFailed', true, this.getErrMsg(err, 'setScoreVisibilityFailed'));
+						this.handleValidationError('_setScoreVisibilityFailed', 'setScoreVisibilityFailed', err);
 					}.bind(this));
 				}
 			},

--- a/editor/d2l-rubric-feedback-editor.html
+++ b/editor/d2l-rubric-feedback-editor.html
@@ -131,7 +131,7 @@
 					this.performSirenAction(action, fields).then(function() {
 						this.fire('d2l-rubric-feedback-saved');
 					}.bind(this)).catch(function() {
-						this.toggleBubble('_feedbackInvalid', true, this.localize('feedbackSaveFailed'));
+						this.handleValidationError('_feedbackInvalid', 'feedbackSaveFailed', err);
 					}.bind(this));
 				}
 			},

--- a/editor/d2l-rubric-feedback-editor.html
+++ b/editor/d2l-rubric-feedback-editor.html
@@ -130,7 +130,7 @@
 					var fields = [{'name':'feedback', 'value':e.detail.value}];
 					this.performSirenAction(action, fields).then(function() {
 						this.fire('d2l-rubric-feedback-saved');
-					}.bind(this)).catch(function() {
+					}.bind(this)).catch(function(err) {
 						this.handleValidationError('_feedbackInvalid', 'feedbackSaveFailed', err);
 					}.bind(this));
 				}

--- a/lang/ar.html
+++ b/lang/ar.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': 'فشل حفظ الملاحظات',
 			'groupAdded': 'تمت إضافة مجموعة معايير جديدة',
 			'groupName': 'اسم مجموعة المعايير',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': 'مجموعة المعايير {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/da.html
+++ b/lang/da.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': 'Det lykkedes ikke at gemme feedbacken',
 			'groupAdded': 'En ny kriteriegruppe blev tilføjet',
 			'groupName': 'Kriteriegruppenavn',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': 'Kriteriegruppe {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/de.html
+++ b/lang/de.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': 'Speichern des Feedbacks fehlgeschlagen',
 			'groupAdded': 'Eine neue Kriteriengruppe wurde hinzugefügt',
 			'groupName': 'Name der Kriteriengruppe',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': 'Kriteriengruppe {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/en.html
+++ b/lang/en.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': 'Saving feedback failed',
 			'groupAdded': 'A new criteria group has been added',
 			'groupName': 'Criteria group name',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': 'Criteria group {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/es.html
+++ b/lang/es.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': 'No se pudo guardar el comentario',
 			'groupAdded': 'Se agregó un nuevo grupo de criterios',
 			'groupName': 'Nombre del grupo de criterios',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': 'Grupo de criterios {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/fi.html
+++ b/lang/fi.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': 'Saving feedback failed',
 			'groupAdded': 'A new criteria group has been added',
 			'groupName': 'Criteria group name',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': 'Criteria group {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/fr.html
+++ b/lang/fr.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': 'Échec de l\'enregistrement de la rétroaction',
 			'groupAdded': 'Un nouveau groupe de critères a été ajouté',
 			'groupName': 'Nom du groupe de critères',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': 'Groupe de critères {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/ja.html
+++ b/lang/ja.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': 'フィードバックを保存できませんでした',
 			'groupAdded': '新しい条件グループが追加されました',
 			'groupName': '条件グループ名',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': '条件グループ {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/ko.html
+++ b/lang/ko.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': '피드백 저장 실패',
 			'groupAdded': '새 기준 그룹이 추가되었습니다.',
 			'groupName': '기준 그룹 이름',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': '기준 그룹 {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/nl.html
+++ b/lang/nl.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': 'Opslaan van feedback mislukt',
 			'groupAdded': 'Een nieuwe criteriagroep is toegevoegd',
 			'groupName': 'Naam criteriagroep',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': 'Criteriagroep {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/pt.html
+++ b/lang/pt.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': 'Falha ao salvar os comentários',
 			'groupAdded': 'Um novo grupo de critérios foi adicionado',
 			'groupName': 'Nome do grupo de critérios',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': 'Grupo de critérios {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/sv.html
+++ b/lang/sv.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': 'Feedback kunde inte sparas',
 			'groupAdded': 'En ny kriteriegrupp har lagts till',
 			'groupName': 'Namn på kriteriegrupp',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': 'Kriteriegrupp {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/tr.html
+++ b/lang/tr.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': 'Geri bildirim kaydedilemedi',
 			'groupAdded': 'Yeni bir kriter grubu eklendi',
 			'groupName': 'Kriter grubu adı',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': '{name} kriter grubu',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/zh-tw.html
+++ b/lang/zh-tw.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': '意見反應儲存失敗',
 			'groupAdded': '已新增標準群組',
 			'groupName': '標準群組名稱',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': '標準群組 {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',

--- a/lang/zh.html
+++ b/lang/zh.html
@@ -43,6 +43,7 @@
 			'feedbackSaveFailed': '保存反馈失败',
 			'groupAdded': '已添加新标准组',
 			'groupName': '标准组名',
+			'groupNameSaveFailed': 'Saving criteria group name failed',
 			'groupRegion': '标准组 {name}',
 			'helpAssociations': 'What are associations?',
 			'hideScore': 'Hide scores from students',


### PR DESCRIPTION
Replace stray `toggleBubble` and `fire` error handling with `handleValidationError`.
Also add missing validation error handling to group editor name, with appropriate langterm.