### PR TITLE
Handle alerts with new d2l-rubric-editor-save-error

### DIFF
--- a/editor/d2l-rubric-criteria-editor.html
+++ b/editor/d2l-rubric-criteria-editor.html
@@ -334,6 +334,8 @@
 						setTimeout(function() {
 							this.fire('iron-announce', { text: this.localize('criterionAdded') }, { bubbles: true });
 						}.bind(this), 2000);
+					}.bind(this)).catch(function(err) {
+						this.fire('d2l-rubric-editor-save-error', { message: err.message });
 					}.bind(this));
 				}
 			},
@@ -395,6 +397,8 @@
 						this.fire('iron-announce',
 							{ text: this.localize('criterionMoved', 'name', criterionName, 'position', newPosition) },
 							{ bubbles: true });
+					}.bind(this)).catch(function(err) {
+						this.fire('d2l-rubric-editor-save-error', { message: err.message });
 					}.bind(this));
 				}
 				return Promise.resolve();

--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -189,7 +189,7 @@
 			],
 
 			ready: function() {
-				this.addEventListener('d2l-siren-entity-save-error', this._handleSaveError.bind(this));
+				this.addEventListener('d2l-rubric-editor-save-error', this._handleSaveError.bind(this));
 				this.addEventListener('d2l-rubric-editor-levels-width-changed', function(e) {
 					this.$$('d2l-rubric-criteria-editor').criterionDetailWidth = e.detail.width;
 				}.bind(this));
@@ -239,7 +239,7 @@
 					}
 				}
 				this.fire('iron-announce', { text: this.localize('rubricSavingErrorAriaAlert') }, { bubbles: true });
-				this._addAlert('error', e.detail.error.message, this.localize('rubricSavingErrorMessage'));
+				this._addAlert('error', e.message, this.localize('rubricSavingErrorMessage'));
 			},
 
 			_canEditGroupName: function(entity) {

--- a/editor/d2l-rubric-criteria-groups-editor.html
+++ b/editor/d2l-rubric-criteria-groups-editor.html
@@ -147,8 +147,9 @@
 						setTimeout(function() {
 							this.fire('iron-announce', { text: this.localize('groupAdded') }, { bubbles: true });
 						}.bind(this), 2000);
-					}.bind(this)).catch(function() {
+					}.bind(this)).catch(function(err) {
 						this._waitingForGroups = false;
+						this.fire('d2l-rubric-editor-save-error', { message: err.message });
 					}.bind(this));
 				}
 			},

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -420,9 +420,10 @@
 						this.fire('d2l-rubric-criterion-deleted');
 					}.bind(this)).then(function() {
 						deleteButton.removeAttribute('disabled');
-					}).catch(function() {
+					}).catch(function(err) {
 						deleteButton.removeAttribute('disabled');
-					});
+						this.fire('d2l-rubric-editor-save-error', { message: err.message });
+					}.bind(this));
 				}.bind(this), function() {
 					deleteButton.removeAttribute('disabled');
 				});

--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -473,7 +473,7 @@ Creates and edits a rubric
 				'_onEntityChanged(entity)'
 			],
 			ready: function() {
-				this.addEventListener('d2l-siren-entity-save-error', this._handleSaveError.bind(this));
+				this.addEventListener('d2l-rubric-editor-save-error', this._handleSaveError.bind(this));
 			},
 			attached: function() {
 				Polymer.IronA11yAnnouncer.requestAvailability();
@@ -490,7 +490,7 @@ Creates and edits a rubric
 			_handleSaveError: function(e) {
 				this._clearAlerts();
 				this.fire('iron-announce', { text: this.localize('rubricSavingErrorAriaAlert') }, { bubbles: true });
-				this._addAlert('error', e.detail.error.message, this.localize('rubricSavingErrorMessage'));
+				this._addAlert('error', e.message, this.localize('rubricSavingErrorMessage'));
 			},
 			_handleAssociations: function(e) {
 				var associationEntity = this._associations[e.currentTarget.value];
@@ -693,9 +693,10 @@ Creates and edits a rubric
 					this.fire('iron-announce', { text: this.localize('changeRubricStatusSuccessful', 'status', e.target.text) }, { bubbles: true });
 				}.bind(this)).then(function() {
 					this.enableMenu(menuButton);
-				}.bind(this)).catch(function() {
+				}.bind(this)).catch(function(err) {
 					this.resetSelectedMenuItem(menuButton, this._rubricStatus);
 					this.enableMenu(menuButton);
+					this.fire('d2l-rubric-editor-save-error', { message: err.message });
 				}.bind(this));
 			},
 			_handleSelectStatistics: function() {

--- a/editor/d2l-rubric-level-editor.html
+++ b/editor/d2l-rubric-level-editor.html
@@ -278,8 +278,9 @@
 						this.fire('d2l-rubric-level-deleted');
 					}.bind(this)).then(function() {
 						deleteButton.removeAttribute('disabled');
-					}).catch(function() {
+					}).catch(function(err) {
 						deleteButton.removeAttribute('disabled');
+						this.fire('d2l-rubric-editor-save-error', { message: err.message });
 					});
 				}.bind(this), function(){
 					deleteButton.removeAttribute('disabled');

--- a/editor/d2l-rubric-levels-editor.html
+++ b/editor/d2l-rubric-levels-editor.html
@@ -196,6 +196,8 @@
 					this.performSirenAction(action).then(function() {
 						this.fire('d2l-rubric-level-added');
 						this.fire('iron-announce', { text: this.localize('levelPrepended', 'name', firstLevelName) }, { bubbles: true });
+					}.bind(this)).catch(function(err) {
+						this.fire('d2l-rubric-editor-save-error', { message: err.message });
 					}.bind(this));
 				}
 			},
@@ -206,6 +208,8 @@
 					this.performSirenAction(action).then(function() {
 						this.fire('d2l-rubric-level-added');
 						this.fire('iron-announce', { text: this.localize('levelAppended', 'name', lastLevelName) }, { bubbles: true });
+					}.bind(this)).catch(function(err) {
+						this.fire('d2l-rubric-editor-save-error', { message: err.message });
 					}.bind(this));
 				}
 			},

--- a/editor/d2l-rubric-overall-level-editor.html
+++ b/editor/d2l-rubric-overall-level-editor.html
@@ -236,8 +236,9 @@
 
 					}.bind(this)).then(function() {
 						deleteButton.removeAttribute('disabled');
-					}).catch(function() {
+					}).catch(function(err) {
 						deleteButton.removeAttribute('disabled');
+						this.fire('d2l-rubric-editor-save-error', { message: err.message });
 					});
 				}.bind(this), function(){
 					deleteButton.removeAttribute('disabled');

--- a/editor/d2l-rubric-overall-levels-editor.html
+++ b/editor/d2l-rubric-overall-levels-editor.html
@@ -319,6 +319,8 @@
 					this.performSirenAction(action).then(function() {
 						this.fire('d2l-rubric-overall-level-added');
 						this.fire('iron-announce', { text: this.localize('addOverallLevelPrepend', 'name', firstLevelName) }, { bubbles: true });
+					}.bind(this)).catch(function(err) {
+						this.fire('d2l-rubric-editor-save-error', { message: err.message });
 					}.bind(this));
 				}
 			},
@@ -329,6 +331,8 @@
 					this.performSirenAction(action).then(function() {
 						this.fire('d2l-rubric-overall-level-added');
 						this.fire('iron-announce', { text: this.localize('addOverallLevelAppend', 'name', lastLevelName) }, { bubbles: true });
+					}.bind(this)).catch(function(err) {
+						this.fire('d2l-rubric-editor-save-error', { message: err.message });
 					}.bind(this));
 				}
 			},

--- a/editor/d2l-rubric-structure-editor.html
+++ b/editor/d2l-rubric-structure-editor.html
@@ -233,7 +233,7 @@ Creates and edits a rubric structue
 
 			listeners: {
 				'd2l-siren-entity-save-start': '_onEntitySave',
-				'd2l-siren-entity-save-error': '_onEntitySave',
+				'd2l-rubric-editor-save-error': '_onEntitySave',
 				'd2l-siren-entity-save-end': '_onEntitySave'
 			},
 
@@ -243,7 +243,7 @@ Creates and edits a rubric structue
 
 			ready: function() {
 				this.addEventListener('d2l-siren-entity-error', this._handleError.bind(this));
-				this.addEventListener('d2l-siren-entity-save-error', this._handleSaveError.bind(this));
+				this.addEventListener('d2l-rubric-editor-save-error', this._handleSaveError.bind(this));
 			},
 
 			attached: function() {
@@ -337,6 +337,8 @@ Creates and edits a rubric structue
 					this.performSirenAction(this._reverseLevels).then(function() {
 						this.fire('d2l-rubric-levels-reversed');
 						this.fire('iron-announce', { text: this.localize('reverseLevelsSuccessful') }, { bubbles: true });
+					}.bind(this)).catch(function(err) {
+						this.fire('d2l-rubric-editor-save-error', { message: err.message });
 					}.bind(this));
 				}
 			},
@@ -345,12 +347,12 @@ Creates and edits a rubric structue
 				this._clearAlerts();
 				e.stopPropagation();
 				this.fire('iron-announce', { text: this.localize('rubricSavingErrorAriaAlert') }, { bubbles: true });
-				this._addAlert('error', e.detail.error.message, this.localize('rubricSavingErrorMessage'));
+				this._addAlert('error', e.message, this.localize('rubricSavingErrorMessage'));
 			},
 
 			_handleError: function(e) {
 				this.fire('iron-announce', { text: this.localize('rubricLoadingErrorAriaAlert') }, { bubbles: true });
-				this._addAlert('error', e.detail.error.message, this.localize('rubricLoadingErrorMessage'));
+				this._addAlert('error', e.message, this.localize('rubricLoadingErrorMessage'));
 				this._displayEditor(false);
 			},
 
@@ -380,9 +382,10 @@ Creates and edits a rubric structue
 						this.fire('iron-announce', { text: this.localize('changeRubricTypeSuccessful', 'rubricType', e.target.text) }, { bubbles: true });
 					}.bind(this)).then(function() {
 						this.enableMenu(menuButton);
-					}.bind(this)).catch(function() {
+					}.bind(this)).catch(function(err) {
 						this.resetSelectedMenuItem(menuButton, this._rubricTypeValue);
 						this.enableMenu(menuButton);
+						this.fire('d2l-rubric-editor-save-error', { message: err.message });
 					}.bind(this));
 				}.bind(this);
 
@@ -416,9 +419,10 @@ Creates and edits a rubric structue
 					this.fire('iron-announce', { text: this.localize('changeScoringSuccessful', 'method', e.target.text) }, { bubbles: true });
 				}.bind(this)).then(function() {
 					this.enableMenu(menuButton);
-				}.bind(this)).catch(function() {
+				}.bind(this)).catch(function(err) {
 					this.resetSelectedMenuItem(menuButton, this._scoringMethod);
 					this.enableMenu(menuButton);
+					this.fire('d2l-rubric-editor-save-error', { message: err.message });
 				}.bind(this));
 
 				Polymer.dom(dropdownMenu).removeAttribute('opened');


### PR DESCRIPTION
Anywhere where we are _not_ handling the errors with `handleValidationError` (which represent those elements which have an associated error bubble), we now use `d2l-rubric-editor-save-error` to trigger alerts where needed. That also allows `d2l-siren-save-entity` to propagate and update the save-status component.