### PR TITLE
Trello IE11 bug: Set default values for field invalid properties

### DIFF
--- a/editor/d2l-rubric-criteria-group-editor.html
+++ b/editor/d2l-rubric-criteria-group-editor.html
@@ -127,7 +127,13 @@
 						prevent-submit>
 					</d2l-input-text>
 				</d2l-rubric-levels-editor>
-				<d2l-tooltip id="group-name-bubble" for="group-name" hidden$="[[!_nameInvalid]]" position="bottom">[[_nameInvalidError]]</d2l-tooltip>
+				<d2l-tooltip
+					id="group-name-bubble"
+					for="group-name"
+					hidden$="[[!_nameInvalid]]"
+					position="bottom">
+					[[_nameInvalidError]]
+				</d2l-tooltip>
 				<!--
 				This flex wrapper div is required to ensure that the d2l-rubric-criteria-editor
 				fills the full width of it's parent when the d2l-rubric-criterion-editor components overflow.
@@ -168,10 +174,12 @@
 					value: false
 				},
 				_nameInvalid: {
-					type: Boolean
+					type: Boolean,
+					value: false
 				},
 				_nameInvalidError: {
-					type: String
+					type: String,
+					value: null
 				},
 				_groupName: {
 					type: String

--- a/editor/d2l-rubric-criterion-editor.html
+++ b/editor/d2l-rubric-criterion-editor.html
@@ -178,7 +178,13 @@
 				placeholder="[[_getNamePlaceholder(localize, displayNamePlaceholder)]]"
 				on-change="_saveName">
 			</d2l-input-textarea>
-			<d2l-tooltip id="criterion-name-bubble" for="name" hidden$="[[!_nameInvalid]]" position="bottom">[[_nameInvalidError]]</d2l-tooltip>
+			<d2l-tooltip
+				id="criterion-name-bubble"
+				for="name"
+				hidden$="[[!_nameInvalid]]"
+				position="bottom">
+				[[_nameInvalidError]]
+			</d2l-tooltip>
 		</div>
 		<div class="criterion-detail" is-holistic$=[[isHolistic]] style$="width: [[criterionDetailWidth]]px;">
 			<div class="criterion-text">
@@ -228,7 +234,13 @@
 						aria-label="[[localize('criterionOutOf', 'name', entity.properties.name, 'value', _outOf)]]"
 						prevent-submit>
 					</d2l-input-text>
-					<d2l-tooltip id="out-of-bubble" for="out-of-textbox" hidden$="[[!_outOfInvalid]]" position="bottom">[[_outOfInvalidError]]</d2l-tooltip>
+					<d2l-tooltip
+						id="out-of-bubble"
+						for="out-of-textbox"
+						hidden$="[[!_outOfInvalid]]"
+						position="bottom">
+						[[_outOfInvalidError]]
+					</d2l-tooltip>
 				</template>
 			</span>
 		</div>
@@ -266,10 +278,12 @@
 					computed: '_isNameRequired(entity)',
 				},
 				_nameInvalid: {
-					type: Boolean
+					type: Boolean,
+					value: false,
 				},
 				_nameInvalidError: {
-					type: String
+					type: String,
+					value: null,
 				},
 				_hasOutOf: {
 					type: Boolean,
@@ -288,10 +302,12 @@
 					computed: '_getOutOfValue(entity)',
 				},
 				_outOfInvalid: {
-					type: Boolean
+					type: Boolean,
+					value: false
 				},
 				_outOfInvalidError: {
-					type: String
+					type: String,
+					value: null
 				},
 				displayNamePlaceholder: {
 					type: Boolean,

--- a/editor/d2l-rubric-description-editor.html
+++ b/editor/d2l-rubric-description-editor.html
@@ -91,8 +91,20 @@
 			rich-text-enabled="[[_richTextAndEditEnabled(richTextEnabled,_canEditDescription)]]"
 		>
 		</d2l-rubric-text-editor>
-		<d2l-tooltip id="description-bubble" for="description" hidden$="[[!_descriptionInvalid]]" position="bottom">[[_descriptionInvalidError]]</d2l-tooltip>
-		<d2l-tooltip id="cell-points-bubble" for="cell-points" hidden$="[[!_pointsInvalid]]" position="bottom">[[_pointsInvalidError]]</d2l-tooltip>
+		<d2l-tooltip
+			id="description-bubble"
+			for="description"
+			hidden$="[[!_descriptionInvalid]]"
+			position="bottom">
+			[[_descriptionInvalidError]]
+		</d2l-tooltip>
+		<d2l-tooltip
+			id="cell-points-bubble"
+			for="cell-points"
+			hidden$="[[!_pointsInvalid]]"
+			position="bottom">
+			[[_pointsInvalidError]]
+		</d2l-tooltip>
 	</template>
 
 	<script>
@@ -128,20 +140,24 @@
 					computed: '_computeCanEditPoints(entity)',
 				},
 				_descriptionInvalid: {
-					type: Boolean
+					type: Boolean,
+					value: false
 				},
 				_descriptionInvalidError: {
-					type: String
+					type: String,
+					value: null
 				},
 				_pointsRequired: {
 					type: Boolean,
 					computed: '_arePointsRequired(entity)',
 				},
 				_pointsInvalid: {
-					type: Boolean
+					type: Boolean,
+					value: false
 				},
 				_pointsInvalidError: {
-					type: String
+					type: String,
+					value: null
 				},
 				_showPoints: {
 					type: Boolean,

--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -238,7 +238,13 @@ Creates and edits a rubric
 				>
 				</d2l-input-text>
 
-				<d2l-tooltip id="name-bubble" for="rubric-name" hidden$="[[!_nameInvalid]]" position="bottom">[[_nameInvalidError]]</d2l-tooltip>
+				<d2l-tooltip
+					id="name-bubble"
+					for="rubric-name"
+					hidden$="[[!_nameInvalid]]"
+					position="bottom">
+					[[_nameInvalidError]]
+				</d2l-tooltip>
 			</template>
 			<template is="dom-if" if="[[_isLocked]]">
 				<h4>[[_rubricName]]</h4>
@@ -282,7 +288,13 @@ Creates and edits a rubric
 						>
 							[[localize('hideScore')]]
 						</d2l-input-checkbox>
-						<d2l-tooltip id="hide-score-bubble" for="hide-score-checkbox" hidden$="[[!_setScoreVisibilityFailed]]" position="bottom">[[_setScoreVisibilityFailedError]]</d2l-tooltip>
+						<d2l-tooltip
+							id="hide-score-bubble"
+							for="hide-score-checkbox"
+							hidden$="[[!_setScoreVisibilityFailed]]"
+							position="bottom">
+							[[_setScoreVisibilityFailedError]]
+						</d2l-tooltip>
 					</div>
 					<div id="rubric-description-container">
 						<template is="dom-if" if="[[!_isLocked]]">
@@ -299,7 +311,13 @@ Creates and edits a rubric
 								rich-text-enabled="[[_richTextAndEditEnabled(richTextEnabled,_canEditDescription)]]"
 							>
 							</d2l-rubric-text-editor>
-							<d2l-tooltip id="rubric-description-bubble" for="rubric-description" hidden$="[[!_descriptionInvalid]]" position="bottom">[[_descriptionInvalidError]]</d2l-tooltip>
+							<d2l-tooltip
+								id="rubric-description-bubble"
+								for="rubric-description"
+								hidden$="[[!_descriptionInvalid]]"
+								position="bottom">
+								[[_descriptionInvalidError]]
+							</d2l-tooltip>
 						</template>
 						<template is="dom-if" if="[[_isLocked]]">
 							<label for="rubric-description">[[localize('descriptionReadOnlyMode')]]</label>
@@ -333,7 +351,13 @@ Creates and edits a rubric
 									</d2l-input-checkbox>
 								</template>
 							</div>
-							<d2l-tooltip id="associations-bubble" for="associations" hidden$="[[!_associationsInvalid]]" position="bottom">[[_associationsInvalidError]]</d2l-tooltip>
+							<d2l-tooltip
+								id="associations-bubble"
+								for="associations"
+								hidden$="[[!_associationsInvalid]]"
+								position="bottom">
+								[[_associationsInvalidError]]
+							</d2l-tooltip>
 						</fieldset>
 						<div class="help-link d2l-body-compact">
 							<d2l-link on-click="_openHelpDialog">[[localize('helpAssociations')]]</d2l-link>
@@ -379,9 +403,11 @@ Creates and edits a rubric
 				},
 				_nameInvalid: {
 					type: Boolean,
+					value: false,
 				},
 				_nameInvalidError: {
-					type: String
+					type: String,
+					value: null,
 				},
 				_nameRequired: {
 					type: Boolean,
@@ -406,9 +432,11 @@ Creates and edits a rubric
 				},
 				_descriptionInvalid: {
 					type: Boolean,
+					value: false,
 				},
 				_descriptionInvalidError: {
-					type: String
+					type: String,
+					value: false,
 				},
 				_canHideScore: {
 					type: Boolean,
@@ -419,10 +447,12 @@ Creates and edits a rubric
 					computed: '_computeScoreIsHidden(entity)'
 				},
 				_setScoreVisibilityFailed: {
-					type: Boolean
+					type: Boolean,
+					value: false,
 				},
 				_setScoreVisibilityFailedError: {
-					type: String
+					type: String,
+					value: null,
 				},
 				_canChangeStatus: {
 					type: Boolean,
@@ -461,10 +491,12 @@ Creates and edits a rubric
 					computed: '_computeAssociations(entity)'
 				},
 				_associationsInvalid: {
-					type: Boolean
+					type: Boolean,
+					value: false,
 				},
 				_associationsInvalidError: {
-					type: String
+					type: String,
+					value: null,
 				},
 				_helpAssociations: {
 					type: Object,

--- a/editor/d2l-rubric-feedback-editor.html
+++ b/editor/d2l-rubric-feedback-editor.html
@@ -46,7 +46,13 @@
 			on-change="_saveFeedback"
 			rich-text-enabled="[[_richTextAndEditEnabled(richTextEnabled,_canEdit)]]"
 		>
-		<d2l-tooltip id="feedback-bubble" for="feedback" hidden$="[[!_feedbackInvalid]]" position="bottom">[[_feedbackInvalidError]]</d2l-tooltip>
+		<d2l-tooltip
+			id="feedback-bubble"
+			for="feedback"
+			hidden$="[[!_feedbackInvalid]]"
+			position="bottom">
+			[[_feedbackInvalidError]]
+		</d2l-tooltip>
 	</template>
 
 	<script>
@@ -71,10 +77,12 @@
 					computed: '_canEditFeedback(entity)',
 				},
 				_feedbackInvalid: {
-					type: Boolean
+					type: Boolean,
+					value: false
 				},
 				_feedbackInvalidError: {
-					type: String
+					type: String,
+					value: null
 				},
 				keyLinkRels: {
 					type: Array,

--- a/editor/d2l-rubric-level-editor.html
+++ b/editor/d2l-rubric-level-editor.html
@@ -101,8 +101,20 @@
 				type="button">
 			</d2l-button-icon>
 		</div>
-		<d2l-tooltip id="level-name-bubble" for="level-name" hidden$="[[!_nameInvalid]]" position="bottom">[[_nameInvalidError]]</d2l-tooltip>
-		<d2l-tooltip id="points-bubble" for="level-points" hidden$="[[!_pointsInvalid]]" position="bottom">[[_pointsInvalidError]]</d2l-tooltip>
+		<d2l-tooltip
+			id="level-name-bubble"
+			for="level-name"
+			hidden$="[[!_nameInvalid]]"
+			position="bottom">
+			[[_nameInvalidError]]
+		</d2l-tooltip>
+		<d2l-tooltip
+			id="points-bubble"
+			for="level-points"
+			hidden$="[[!_pointsInvalid]]"
+			position="bottom">
+			[[_pointsInvalidError]]
+		</d2l-tooltip>
 	</template>
 
 	<script>
@@ -125,10 +137,12 @@
 					computed: '_isNameRequired(entity)',
 				},
 				_nameInvalid: {
-					type: Boolean
+					type: Boolean,
+					value: false
 				},
 				_nameInvalidError: {
-					type: String
+					type: String,
+					value: null
 				},
 				_canEditPoints: {
 					type: Boolean,
@@ -139,10 +153,12 @@
 					computed: '_arePointsRequired(entity)',
 				},
 				_pointsInvalid: {
-					type: Boolean
+					type: Boolean,
+					value: false
 				},
 				_pointsInvalidError: {
-					type: String
+					type: String,
+					value: null
 				},
 				_showPoints: {
 					type: Boolean,

--- a/editor/d2l-rubric-overall-level-editor.html
+++ b/editor/d2l-rubric-overall-level-editor.html
@@ -88,8 +88,20 @@
 				type="button">
 			</d2l-button-icon>
 		</div>
-		<d2l-tooltip id="overall-level-name-bubble" for="overall-level-name" hidden$="[[!_nameInvalid]]" position="bottom">[[_nameInvalidError]]</d2l-tooltip>
-		<d2l-tooltip id="range-start-bubble" for="range-start" hidden$="[[!_rangeStartInvalid]]" position="bottom">[[_rangeStartInvalidError]]</d2l-tooltip>
+		<d2l-tooltip
+			id="overall-level-name-bubble"
+			for="overall-level-name"
+			hidden$="[[!_nameInvalid]]"
+			position="bottom">
+			[[_nameInvalidError]]
+		</d2l-tooltip>
+		<d2l-tooltip
+			id="range-start-bubble"
+			for="range-start"
+			hidden$="[[!_rangeStartInvalid]]"
+			position="bottom">
+			[[_rangeStartInvalidError]]
+		</d2l-tooltip>
 	</template>
 	<script>
 		Polymer({
@@ -113,10 +125,12 @@
 					computed: '_isNameRequired(entity)',
 				},
 				_nameInvalid: {
-					type: Boolean
+					type: Boolean,
+					value: false
 				},
 				_nameInvalidError: {
-					type: String
+					type: String,
+					value: null
 				},
 				_hasRangeStart: {
 					type: Boolean,
@@ -127,10 +141,12 @@
 					computed: '_isRangeStartRequired(entity)',
 				},
 				_rangeStartInvalid: {
-					type: Boolean
+					type: Boolean,
+					value: false
 				},
 				_rangeStartInvalidError: {
-					type: String
+					type: String,
+					value: null
 				},
 			},
 			observers: [

--- a/editor/d2l-rubric-visibility-editor.html
+++ b/editor/d2l-rubric-visibility-editor.html
@@ -50,7 +50,8 @@
 		<label class="d2l-input-radio-label">
 			<input type="radio" id="VisibleOnceFeedbackPosted" on-focus="_handleFocus" on-blur="_handleBlur" value="VisibleOnceFeedbackPosted" name="visibility" on-change="_changeVisibility"></input>[[localize('rubricVisibilityOnceFeedbackPosted')]]
 		</label>
-		<d2l-tooltip id="visibility-bubble" hidden$="[[!_visibilityInvalid]]" position="bottom">[[_visibilityInvalidError]]</d2l-tooltip>
+		<d2l-tooltip
+			id="visibility-bubble" hidden$="[[!_visibilityInvalid]]" position="bottom">[[_visibilityInvalidError]]</d2l-tooltip>
 	</template>
 	<script>
 		Polymer({
@@ -78,10 +79,12 @@
 					computed: '_computeAriaInvalid(_visibilityInvalid)'
 				},
 				_visibilityInvalid: {
-					type: Boolean
+					type: Boolean,
+					value: false
 				},
 				_visibilityInvalidError: {
-					type: String
+					type: String,
+					value: null
 				},
 			},
 			behaviors: [


### PR DESCRIPTION
Addresses https://trello.com/c/ZoNFw4qM/21-weird-tooltip-bubbles-appearing-when-highlighting-fields-in-the-accordion-menu-on-ie11
IE11 doesn't like properties without default values, so set the default for the various `fooInvalid` properties to `false`.
Also formatted the tooltips, but didn't actually change them.