### PR TITLE
fix jumpy radio buttons in mac safari

### DIFF
--- a/editor/d2l-rubric-editor.html
+++ b/editor/d2l-rubric-editor.html
@@ -55,6 +55,10 @@ Creates and edits a rubric
 				margin-top: 1.2rem;
 			}
 
+			#visibility-container {
+				line-height: 0;
+			}
+
 			#hide-score-container {
 				margin-top: 2.15rem;
 			}
@@ -271,7 +275,7 @@ Creates and edits a rubric
 		<div id="accordion-container">
 			<d2l-accordion-collapse title="[[localize('options')]]" flex opened$="[[_isLocked]]">
 				<div id="options-container">
-					<div>
+					<div id="visibility-container">
 						<d2l-rubric-visibility-editor
 							href=[[href]]
 							token=[[token]]

--- a/editor/d2l-rubric-visibility-editor.html
+++ b/editor/d2l-rubric-visibility-editor.html
@@ -19,7 +19,6 @@
 		<style include="d2l-input-radio-styles d2l-input-styles">
 			:host {
 				display: inline-block;
-				overflow: hidden;
 			}
 			:host([aria-invalid="true"]) {
 				padding: var(--d2l-input-padding);


### PR DESCRIPTION
The combination of a `display: block` div with a `display: inline-block` visibility component was causing the size of the outer div to change with the change in the border of the radio even though the radio button dimensions were not changing. Totally weird.

Setting a `line-height: 0` on the outer div (CSS shoot an arrow while blindfolded and see where it lands), seems to resolve it. I removed the `overflow: hidden` which I'd previously added to fix the same issue in Chrome. This solution fixes it in Chrome and Safari.