### PR TITLE
[Polymer 3] US100917 -- Allow criterion assessments with no selected level to still have their score overridden

### DIFF
--- a/assessment-result-behavior.js
+++ b/assessment-result-behavior.js
@@ -68,6 +68,19 @@ D2L.PolymerBehaviors.Rubric.AssessmentResultBehaviorImpl = {
 			if (!selectedCriterionCellEntity) {
 				// No selected cell in this row, so reset prevLink
 				prevLink = null;
+
+				if (criterionEntity.properties && criterionEntity.properties.score != null) { //eslint-disable-line eqeqeq
+					var criterionHref = criterionEntity.getLinkByRel(this.HypermediaRels.Rubrics.criterion).href;
+					var feedback = criterionEntity.getSubEntityByClass(this.HypermediaClasses.rubrics.feedback) || {};
+					assessmentMap[criterionHref] = {
+						score: criterionEntity.properties.score,
+						level: null,
+						feedback: feedback.text,
+						feedbackText: feedback.html,
+						cellEntity: null
+					};
+				}
+
 				continue;
 			}
 


### PR DESCRIPTION
LMS PR: https://git.dev.d2l/projects/CORE/repos/lp/pull-requests/12173/overview
Polymer 1 PR: https://github.com/Brightspace/d2l-rubric/pull/434