### PR TITLE
Vwong/polymer 3 bug fixes

### DIFF
--- a/assessment-result-behavior.js
+++ b/assessment-result-behavior.js
@@ -1,5 +1,5 @@
 import 'd2l-hypermedia-constants/d2l-hypermedia-constants.js';
-import 'd2l-polymer-siren-behaviors/store/entity-behavior.js';
+import './d2l-rubric-entity-behavior.js';
 import 'd2l-polymer-siren-behaviors/store/siren-action-behavior.js';
 window.D2L = window.D2L || {};
 window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};

--- a/editor/d2l-rubric-editor.js
+++ b/editor/d2l-rubric-editor.js
@@ -674,19 +674,20 @@ Polymer({
 	},
 	_handleStatusChange: function(e) {
 		var menuButton = e.currentTarget;
+		var menuItem = e.target;
 		var dropdownMenu = dom(menuButton).querySelector('d2l-dropdown-menu');
-		if (!this._canChangeStatus || e.target.value === this._rubricStatus) return;
+		if (!this._canChangeStatus || menuItem.value === this._rubricStatus) return;
 
 		dom(dropdownMenu).removeAttribute('opened');
 		this.disableMenu(menuButton);
 
 		var action = this.entity.getActionByName('update-status');
-		var fields = [{'name':'status', 'value':e.target.value}];
+		var fields = [{'name':'status', 'value':menuItem.value}];
 		this.performSirenAction(action, fields).then(function() {
-			this._rubricStatusText = this.localize('rubricStatus', 'status', e.target.text);
-			this._rubricStatus = e.target.value;
+			this._rubricStatusText = this.localize('rubricStatus', 'status', menuItem.text);
+			this._rubricStatus = menuItem.value;
 			this.fire('d2l-rubric-status-changed');
-			this.fire('iron-announce', { text: this.localize('changeRubricStatusSuccessful', 'status', e.target.text) }, { bubbles: true });
+			this.fire('iron-announce', { text: this.localize('changeRubricStatusSuccessful', 'status', menuItem.text) }, { bubbles: true });
 		}.bind(this)).then(function() {
 			this.enableMenu(menuButton);
 		}.bind(this)).catch(function(err) {

--- a/editor/d2l-rubric-html-editor.js
+++ b/editor/d2l-rubric-html-editor.js
@@ -71,8 +71,7 @@ Polymer({
 			}
 
 		</style>
-		<d2l-html-editor editor-id="[[_uniqueId]]" key="[[key]]" inline="1" auto-focus="[[autoFocus]]" auto-focus-end="" min-rows="1" max-rows="1000" app-root="[[_appRoot]]" fullpage-enabled="0" content="[[_encodeURIComponent(value)]]" toolbar="[[_toolbar]]" plugins="[[_plugins]]" object-resizing="[[objectResizing]]" on-focus="_showToolbar" on-blur="_hideToolbar">
-		<div id$="[[_uniqueId]]-toolbar" hidden="" class="toolbar"></div>
+		<d2l-html-editor editor-id="[[_uniqueId]]" key="[[key]]" inline="1" auto-focus="[[autoFocus]]" auto-focus-end="" min-rows="1" max-rows="1000" app-root="[[_appRoot]]" fullpage-enabled="0" content="[[_encodeURIComponent(value)]]" toolbar="[[_toolbar]]" plugins="[[_plugins]]" object-resizing="[[objectResizing]]">
 		<div id$="toolbar-shortcut-[[_uniqueId]]" hidden=""></div>
 		<div class="d2l-richtext-editor-container" id="[[_uniqueId]]" role="textbox" placeholder$="[[placeholder]]" aria-label$="[[ariaLabel]]"></div>
 		</d2l-html-editor>
@@ -181,13 +180,5 @@ Polymer({
 
 	_encodeURIComponent: function(value) {
 		return value ? encodeURIComponent(value) : '';
-	},
-
-	_showToolbar: function() {
-		this.$$('.toolbar').removeAttribute('hidden');
-	},
-
-	_hideToolbar: function() {
-		this.$$('.toolbar').setAttribute('hidden', true);
 	}
 });

--- a/editor/d2l-rubric-html-editor.js
+++ b/editor/d2l-rubric-html-editor.js
@@ -1,6 +1,5 @@
 import '@polymer/polymer/polymer-legacy.js';
 import 'd2l-html-editor/d2l-html-editor-client.js';
-import 'd2l-html-editor/d2l-html-editor-component.js';
 import 'd2l-html-editor/d2l-html-editor.js';
 import 'd2l-inputs/d2l-input-shared-styles.js';
 import 'd2l-hypermedia-constants/d2l-hypermedia-constants.js';

--- a/editor/d2l-rubric-structure-editor.js
+++ b/editor/d2l-rubric-structure-editor.js
@@ -144,7 +144,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-structure-editor">
 		</div>
 	</template>
 
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);
@@ -360,22 +360,23 @@ Polymer({
 
 	_handleTypeChange: function(e) {
 		var menuButton = e.currentTarget;
+		var menuItem = e.target;
 		var dropdownMenu = dom(menuButton).querySelector('d2l-dropdown-menu');
-		if (!this._canConvertType || e.target.value === this._rubricTypeValue) return;
+		if (!this._canConvertType || menuItem.value === this._rubricTypeValue) return;
 
 		dom(dropdownMenu).removeAttribute('opened');
-		var confirm = this._rubricTypeValue === 'Analytic' && e.target.value === 'Holistic';
+		var confirm = this._rubricTypeValue === 'Analytic' && menuItem.value === 'Holistic';
 
 		var performAction = function() {
 			this.disableMenu(menuButton);
 			var action = this.entity.getActionByName('update-type');
-			var fields = [{'name':'rubricType', 'value':e.target.value}];
+			var fields = [{'name':'rubricType', 'value':menuItem.value}];
 			this._refreshScoring = true;
 			this.performSirenAction(action, fields).then(function() {
-				this._rubricTypeText = this.localize('rubricType', 'rubricType', e.target.text);
-				this._rubricTypeValue = e.target.value;
+				this._rubricTypeText = this.localize('rubricType', 'rubricType', menuItem.text);
+				this._rubricTypeValue = menuItem.value;
 				this.fire('d2l-rubric-type-changed');
-				this.fire('iron-announce', { text: this.localize('changeRubricTypeSuccessful', 'rubricType', e.target.text) }, { bubbles: true });
+				this.fire('iron-announce', { text: this.localize('changeRubricTypeSuccessful', 'rubricType', menuItem.text) }, { bubbles: true });
 			}.bind(this)).then(function() {
 				this.enableMenu(menuButton);
 			}.bind(this)).catch(function(err) {

--- a/editor/d2l-rubric-structure-editor.js
+++ b/editor/d2l-rubric-structure-editor.js
@@ -401,19 +401,20 @@ Polymer({
 	},
 	_handleScoringChange: function(e) {
 		var menuButton = e.currentTarget;
+		var menuItem = e.target;
 		var dropdownMenu = dom(menuButton).querySelector('d2l-dropdown-menu');
 
-		if (!this._canConvertScoring || e.target.value === this._scoringMethod)
+		if (!this._canConvertScoring || menuItem.value === this._scoringMethod)
 			return;
 
 		this.disableMenu(menuButton);
 		var action = this.entity.getActionByName('update-scoring');
-		var fields = [{'name':'scoringMethod', 'value':e.target.value}];
+		var fields = [{'name':'scoringMethod', 'value':menuItem.value}];
 		this.performSirenAction(action, fields).then(function() {
-			this._scoringText = this.localize('scoring', 'method', e.target.text);
-			this._scoringMethod = e.target.value;
+			this._scoringText = this.localize('scoring', 'method', menuItem.text);
+			this._scoringMethod = menuItem.value;
 			this.fire('d2l-rubric-scoring-changed');
-			this.fire('iron-announce', { text: this.localize('changeScoringSuccessful', 'method', e.target.text) }, { bubbles: true });
+			this.fire('iron-announce', { text: this.localize('changeScoringSuccessful', 'method', menuItem.text) }, { bubbles: true });
 		}.bind(this)).then(function() {
 			this.enableMenu(menuButton);
 		}.bind(this)).catch(function(err) {


### PR DESCRIPTION
- Remove import of d2l-html-editor-component.js as d2l-html-editor has been fixed to dynamically load it.
- Import missing rubric-entity-behavior behavior.
- Remove unnecessary d2l-html-editor toolbar div as the html-editor toolbar is now rendered by tinymce instead of in the div.

- Some minor dropdown button issues (rubric type, scoring type, status) due to event target changing (d2l-html-editor is stealing the focus. maybe a bigger issue?)