### PR TITLE
Fix focus not returning to rubric type dropdown button after closing LMS confirm dialog

### DIFF
--- a/editor/d2l-rubric-structure-editor.js
+++ b/editor/d2l-rubric-structure-editor.js
@@ -396,6 +396,8 @@ Polymer({
 				negativeButtonText: this.localize('changeConfirmationNo')
 			}).then(performAction, function() {
 				this.resetSelectedMenuItem(menuButton, this._rubricTypeValue);
+			}.bind(this)).finally(function() {
+				menuButton.focus();
 			}.bind(this));
 		}
 	},

--- a/editor/d2l-rubric-structure-editor.js
+++ b/editor/d2l-rubric-structure-editor.js
@@ -379,10 +379,12 @@ Polymer({
 				this.fire('iron-announce', { text: this.localize('changeRubricTypeSuccessful', 'rubricType', menuItem.text) }, { bubbles: true });
 			}.bind(this)).then(function() {
 				this.enableMenu(menuButton);
+				menuButton.focus();
 			}.bind(this)).catch(function(err) {
 				this.resetSelectedMenuItem(menuButton, this._rubricTypeValue);
 				this.enableMenu(menuButton);
 				this.fire('d2l-rubric-editor-save-error', { message: err.message });
+				menuButton.focus();
 			}.bind(this));
 		}.bind(this);
 
@@ -396,7 +398,6 @@ Polymer({
 				negativeButtonText: this.localize('changeConfirmationNo')
 			}).then(performAction, function() {
 				this.resetSelectedMenuItem(menuButton, this._rubricTypeValue);
-			}.bind(this)).finally(function() {
 				menuButton.focus();
 			}.bind(this));
 		}


### PR DESCRIPTION


https://trello.com/c/3KLZUuyJ/79-rubrics-focus-resets-to-window-after-analytic-holistic-warning-popup-is-closed