### PR TITLE
fix html editor change event. Need to check specifically for presence…

### DIFF
--- a/editor/d2l-rubric-text-editor.js
+++ b/editor/d2l-rubric-text-editor.js
@@ -76,7 +76,8 @@ Polymer({
 
 	_onInputChange: function(e) {
 		e.stopPropagation();
-		var value = (e.detail && e.detail.content) || e.target.value || '';
+		var value = (e.detail && e.detail.hasOwnProperty('content')) ?
+			e.detail.content : e.target.value || '';
 		this.fire('change', { value: value });
 	}
 });


### PR DESCRIPTION
… of event.detail.content property as if editor is empty and we default to checking e.target.value, this will no longer be the html editor instance due to event retargetting and so it will return the initial value of the rubric-html-editor which is no longer current