### PR TITLE
Fix criterion name to not be jumpy on hover out

### DIFF
--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -37,6 +37,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 					min-height: 0;
 					overflow: hidden;
 					hyphens: auto;
+					border-color: transparent;
+					box-shadow: none;
+					border-radius: 0;
+					transition-property: none;
 				};
 			}
 
@@ -168,7 +172,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 			<slot name="gutter-left"></slot>
 		</div>
 		<div class="cell col-first criterion-name" hidden$="[[isHolistic]]">
-			<d2l-input-textarea id="name" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label="[[localize('criterionNameAriaLabel')]]" disabled="[[!_canEdit]]" no-border="" hover-styles="" value="[[entity.properties.name]]" placeholder="[[_getNamePlaceholder(localize, displayNamePlaceholder)]]" on-change="_saveName">
+			<d2l-input-textarea id="name" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label="[[localize('criterionNameAriaLabel')]]" disabled="[[!_canEdit]]" value="[[entity.properties.name]]" placeholder="[[_getNamePlaceholder(localize, displayNamePlaceholder)]]" on-change="_saveName">
 			</d2l-input-textarea>
 			<d2l-tooltip id="criterion-name-bubble" for="name" hidden$="[[!_nameInvalid]]" position="bottom">
 				[[_nameInvalidError]]


### PR DESCRIPTION
https://trello.com/c/wedhAqBv/100-rubrics-jumpy-criterion-name-on-hover-out

copied styles from here: https://github.com/Brightspace/d2l-rubric/blob/master/editor/d2l-rubric-description-editor.js#L22