### PR TITLE
Fix IE Html Editor borders on selection

### DIFF
--- a/editor/d2l-rubric-html-editor.js
+++ b/editor/d2l-rubric-html-editor.js
@@ -49,23 +49,23 @@ Polymer({
 				@apply --d2l-input-invalid;
 			}
 
-			/* .d2l-richtext-editor-container p {
-			margin: 1rem 0;
-			} */
 			d2l-html-editor .d2l-richtext-editor-container > p:last-of-type {
-			margin-bottom: 0;
+				margin-bottom: 0;
 			}
 
 			d2l-html-editor .d2l-richtext-editor-container > p:first-of-type {
-			margin-top: 0;
+				margin-top: 0;
 			}
 
 			d2l-html-editor .d2l-richtext-editor-container * {
-			max-width: 100%;
+				max-width: 100%;
 			}
-			/* .d2l-richtext-editor-container p:only-of-type {
-			margin: 0;
-			} */
+
+			@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+				d2l-html-editor .d2l-richtext-editor-container * {
+					max-width: none;
+				}
+			}
 
 			d2l-html-editor.invalid > .d2l-richtext-editor-container:hover,
 			d2l-html-editor.invalid > .d2l-richtext-editor-container:focus {


### PR DESCRIPTION
The html-editor is showing a selection / resize border in IE as the styles we hacked to the renderer (in the LMS) were no longer applying after our polymer 3 conversion.

Solution is to copy those styles to the rubric html-editor.

https://trello.com/c/0ognzPCN/106-ie-11-focusing-on-html-field-shows-an-outline-w-drag-handles
![image](https://user-images.githubusercontent.com/8463897/51773735-a23ad200-20a4-11e9-91a5-dbf156f68a0f.png)
