### PR TITLE
Use ES5 compliant syntax for setting CSS

### DIFF
--- a/editor/d2l-rubric-overall-levels-editor.js
+++ b/editor/d2l-rubric-overall-levels-editor.js
@@ -238,7 +238,7 @@ Polymer({
 			var fromSection = this.$['level-header-center-section'];
 			var toSection = this.$['description-center-section'];
 			if (fromSection) {
-				toSection.style = 'width: ' + fromSection.offsetWidth + 'px;';
+				toSection.style.cssText = 'width: ' + fromSection.offsetWidth + 'px;';
 			}
 			this._notifyResize();
 		}.bind(this), 1);


### PR DESCRIPTION
Addresses: https://trello.com/c/GiLs6N2V/115-rubricsie-console-error-line-1-error-assignment-to-read-only-properties-is-not-allowed-in-strict-mode

Apparently setting `style` directly is not ES5 compliant: https://devtidbits.com/2016/06/12/assignment-to-read-only-properties-is-not-allowed-in-strict-mode/