### PR TITLE
Set HTML content in target div explicitly to get faster initial render

### DIFF
--- a/demo/d2l-rubric-editor.html
+++ b/demo/d2l-rubric-editor.html
@@ -94,7 +94,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container">
 	<h3>Rubric Editor</h3>
 	<p></p>
 	<demo-snippet>
-		<d2l-rubric-editor href="static-data/rubrics/organizations/editable/242.json" token=""></d2l-rubric-editor>
+		<d2l-rubric-editor rich-text-enabled href="static-data/rubrics/organizations/editable/242.json" token=""></d2l-rubric-editor>
 	</demo-snippet>
 </div>`;
 

--- a/editor/d2l-rubric-html-editor.js
+++ b/editor/d2l-rubric-html-editor.js
@@ -161,7 +161,7 @@ Polymer({
 		},
 		_plugins: {
 			type: String,
-			value: 'lists paste d2l_placeholder d2l_isf d2l_replacestring d2l_equation',
+			value: 'lists paste d2l_placeholder d2l_isf d2l_replacestring d2l_equation d2l_xsplconverter',
 		},
 		objectResizing: {
 			type: Boolean,

--- a/editor/d2l-rubric-html-editor.js
+++ b/editor/d2l-rubric-html-editor.js
@@ -83,9 +83,22 @@ Polymer({
 			}
 
 		</style>
-		<d2l-html-editor editor-id="[[_uniqueId]]" key="[[key]]" inline="1" auto-focus="[[autoFocus]]" auto-focus-end="" min-rows="1" max-rows="1000" app-root="[[_appRoot]]" fullpage-enabled="0" content="[[_encodeURIComponent(value)]]" toolbar="[[_toolbar]]" plugins="[[_plugins]]" object-resizing="[[objectResizing]]">
-		<div id$="toolbar-shortcut-[[_uniqueId]]" hidden=""></div>
-		<div class="d2l-richtext-editor-container" id="[[_uniqueId]]" role="textbox" placeholder$="[[placeholder]]" aria-label$="[[ariaLabel]]"></div>
+		<d2l-html-editor 
+			editor-id="[[_uniqueId]]" 
+			inline="1" 
+			auto-focus="[[autoFocus]]" 
+			auto-focus-end="" 
+			min-rows="1" 
+			max-rows="1000" 
+			app-root="[[_appRoot]]" 
+			fullpage-enabled="0" 
+			toolbar="[[_toolbar]]" 
+			plugins="[[_plugins]]" 
+			object-resizing="[[objectResizing]]">
+
+			<div id$="toolbar-shortcut-[[_uniqueId]]" hidden=""></div>
+			<div class="d2l-richtext-editor-container" id="[[_uniqueId]]" role="textbox" placeholder$="[[placeholder]]" aria-label$="[[ariaLabel]]"></div>
+			
 		</d2l-html-editor>
 `,
 
@@ -131,6 +144,7 @@ Polymer({
 		},
 		key: {
 			type: String,
+			observer: '_keyChanged',
 		},
 		_appRoot: {
 			type: String,
@@ -147,7 +161,7 @@ Polymer({
 		},
 		_plugins: {
 			type: String,
-			value: 'lists paste d2l_placeholder d2l_filter d2l_isf d2l_replacestring d2l_equation',
+			value: 'lists paste d2l_placeholder d2l_isf d2l_replacestring d2l_equation',
 		},
 		objectResizing: {
 			type: Boolean,
@@ -173,7 +187,7 @@ Polymer({
 		window.D2L.Siren.EntityStore
 			.get(this.HypermediaRels.richTextEditorConfig, this.token)
 			.then(function(entity) {
-				this.$$('d2l-html-editor').d2lPluginSettings = entity.properties;
+				this.$$('d2l-html-editor').d2lPluginSettings = entity ? entity.properties : {};
 			}.bind(this));
 	},
 
@@ -190,7 +204,7 @@ Polymer({
 		this.toggleClass('invalid', isInvalid, htmlEditor);
 	},
 
-	_encodeURIComponent: function(value) {
-		return value ? encodeURIComponent(value) : '';
-	}
+	_keyChanged: function(newKey, oldKey) {
+		this.$$('#' + this._uniqueId).innerHTML = this.value;
+	},
 });


### PR DESCRIPTION
Modify rubric html editor to set the html content into the tinymce target div explicitly using innerHtml rather than using setContent so that we can get a much faster initial render of the html content. Includes removing the d2l-html-editor filter plugin. Instead we will filter the HTML data in the initial rubric API call. Also added in a missing d2l_xsplconverter plugin which does some funky handling of cross site, non-whitelisted iframes.

See: https://git.dev.d2l/projects/CORE/repos/lp/pull-requests/12335/overview

We want to ensure we only set the innerHtml when the current entity changes. This is because tinymce works kind of like an uncontrolled component in React (https://reactjs.org/docs/uncontrolled-components.html). Once we set the initial content in the tinymce editor, tinymce is managing the state. 

So we don't want to keep resetting that state every time we process a change event from tinymce and do an API call re-render cycle, as that could cause the current editing context in tinymce to be lost.

Instead we use a 'key' mechanism that is set by the parent component (e..g the description/feedback editor) based on the entityId being editing. And we only force a refresh of the tinymce content when that key changes which can happen when levels are reversed, added/removed or criterion or re-sorted and the dom-repeat tries to reuse the same tinymce instances to render a different criterion cell.

# Overview
This slow initial rendering is caused by the initialization approach currently being used by d2l-html-editor. There's a lot of history behind it. We originally just rendered the initial HTML content into the innerHTML of the `div` where we tell tinymce to create the editor. This had problems with React if the HTML was in anyway malformed. So we switched to using the tinymce API to `setContent` after the editor had initialized. This was then later moved to the filter plugin for various reasons which seem somewhat ill advised now.

The impact of this is that we don't set the content of the tinymce editor until the editor has initialized. And tinymce seems to load in such a way that the tinymce `onInit` callback is not called until all editors on the page are initialized. So the more editors you have, the longer the delay before we set the content on any of them. (Ideally we'd work out how to avoid that too...)

For Rubrics/Activity Feed, this initialization approach doesn't seem to make sense. We should be able to set the html content as the innerHtml of the target div, when we first set up the component. That way it will render immediately that the d2l-html-editor component is rendered, and will not be held up by the tinymce initialization.

One side effect of this is that we will not be using the existing d2l-html-editor filter plugin. This was initially implemented to do HTML filtering by calling the LMS filtering API before we set the content in the editor. 

This also seems kind of convoluted. We call an API to get data to put in the editor, then we call another API to filter that data. Why not filter the data in the first API call.

I think the reason we did this initially for quizzing is because we thought the API should get unfiltered HTML in case other 'clients' want to have their own filtering applied. But with hindsight that is too idealistic. 

# Plan

## Change d2l-html-editor usage
Modify our usage of d2l-html-editor to set the html content directly into the innerHTML of the div whilst we are waiting for tinymce to initialize.
This means the HTML will be rendered by the browser but you will still need to wait until all editors are initizalized before you can edit.

Remove the d2l_filter plugin from our usage as it will no longer be used.

## Modify our rubric API to apply filtering to 'RichTextEditor' content in the API
Call the same filtering implementation as used by 
http://search.dev.d2l/source/xref/Lms/lp/framework/web/D2L.LP.Web.UI/Desktop/WebPages/Controllers/HtmlEditorController.cs#223

Apply this to the RubricsService where it sets up the HTML content for editing.

