### PR TITLE
Fix build and bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-rubric",
   "name": "d2l-rubric",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "directories": {
     "test": "test"
   },
@@ -75,7 +75,7 @@
     "d2l-tooltip": "BrightspaceUI/tooltip#semver:^3",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "fastdom": "^1.0.8",
-    "s-html": "Brightspace/s-html#semver:^2.0.0"
+    "s-html": "Brightspace/s-html#semver:^2"
   },
   "resolutions": {
     "inherits": "2.0.3",


### PR DESCRIPTION
BSI is having trouble building. In `d2l-opt-in-flyout-webcomponent`, I added a new dependency on `s-html`. 

Quoting DLockhart from slack:
> The special git `semver:^1.0.0` syntax we’re using will result in multiple copies of a dependency for each different pattern. So if there was `semver:^1.0.0` and `semver:^1.0.1` you’d have two copies.

> The solution we’ve been applying today to everything is to reference things without the minor or patch versions: `semver:^1`.


Sort of skeptical this will fix it though, but never know...