### PR TITLE
Criterion Editor overlay scrolls properly with select-outcomes

### DIFF
--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -207,7 +207,8 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-criterion-ed
 			.scrollable {
 				border: 1px solid lightgray;
 				padding: 24px;
-				@apply --layout-scroll;
+				display: flex;
+				flex-direction: column;
 			}
 
 			:dir(rtl) .criterion-remove {


### PR DESCRIPTION
Needs [this activity alignments PR](https://github.com/Brightspace/d2l-activity-alignments/pull/57)