### PR TITLE
bug fix for empty alignment

### DIFF
--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -346,14 +346,13 @@ Polymer({
 		},
 		_hideBrowseOutcomesButton:{
 			type: Boolean,
-			computed: '_canHideBrowseOutcomesButton(entity, _hasOutOf, isHolistic, _isAlignmentTagListEmpty)',
+			computed: '_canHideBrowseOutcomesButton(entity, _hasOutOf, isHolistic, _isAlignmentTagListEmpty, _isOutcomeEmpty)',
 		},
 		_isAlignmentTagListEmpty:{
 			type:Boolean,
 		},
 		_isOutcomeEmpty: {
 			type: Boolean,
-			value: false,
 		},
 		_nameInvalid: {
 			type: Boolean,


### PR DESCRIPTION
now the button should hide with another PR in activity alignment
https://github.com/Brightspace/d2l-activity-alignments/pull/70