### PR TITLE
DE33486 Stop Firefox opening new tabs when dragging-and-dropping criteria

### DIFF
--- a/editor/d2l-rubric-editor.js
+++ b/editor/d2l-rubric-editor.js
@@ -494,18 +494,18 @@ Polymer({
 
 		// stop firefox opening random extra tabs when dragging (DE33486)
 		if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-			document.body.ondragover = function(event) {
+			addEventListener('dragover', event => {
 				if (event.dataTransfer) {
 					event.stopPropagation();
 					event.preventDefault();
 				}
-			};
-			document.body.ondrop = function(event) {
+			});
+			addEventListener('drop', event => {
 				if (event.dataTransfer) {
 					event.stopPropagation();
 					event.preventDefault();
 				}
-			};
+			});
 		}
 	},
 	attached: function() {

--- a/editor/d2l-rubric-editor.js
+++ b/editor/d2l-rubric-editor.js
@@ -491,6 +491,22 @@ Polymer({
 	],
 	ready: function() {
 		this.addEventListener('d2l-rubric-editor-save-error', this._handleSaveError.bind(this));
+
+		// stop firefox opening random extra tabs when dragging (DE33486)
+		if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
+			document.body.ondragover = function(event) {
+				if (event.dataTransfer) {
+					event.stopPropagation();
+					event.preventDefault();
+				}
+			};
+			document.body.ondrop = function(event) {
+				if (event.dataTransfer) {
+					event.stopPropagation();
+					event.preventDefault();
+				}
+			};
+		}
 	},
 	attached: function() {
 		IronA11yAnnouncer.requestAvailability();


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/detail/defect/295128710624

This is a known issue/firefox feature https://github.com/SortableJS/Sortable/issues/985.
It was fixed in a later version of sortablejs, but we're fixed to an older version because of polymer build issues.