### PR TITLE
DE33690 remove duplicate observer on entity property

### DIFF
--- a/editor/d2l-rubric-criteria-group-editor.js
+++ b/editor/d2l-rubric-criteria-group-editor.js
@@ -153,10 +153,6 @@ Polymer({
 		D2L.PolymerBehaviors.Rubric.ErrorHandlingBehavior
 	],
 
-	observers: [
-		'_onEntityChanged(entity)',
-	],
-
 	ready: function() {
 		this.addEventListener('d2l-rubric-editor-save-error', this._handleSaveError.bind(this));
 		this.addEventListener('d2l-rubric-editor-levels-width-changed', function(e) {

--- a/editor/d2l-rubric-criteria-groups-editor.js
+++ b/editor/d2l-rubric-criteria-groups-editor.js
@@ -138,10 +138,6 @@ Polymer({
 		D2L.PolymerBehaviors.Siren.SirenActionBehavior
 	],
 
-	observers: [
-		'_onEntityChanged(entity)'
-	],
-
 	_onEntityChanged: function(entity) {
 		if (!entity) {
 			return;

--- a/editor/d2l-rubric-description-editor.js
+++ b/editor/d2l-rubric-description-editor.js
@@ -165,9 +165,6 @@ Polymer({
 		},
 		richTextEnabled: Boolean
 	},
-	observers: [
-		'_onEntityChanged(entity)'
-	],
 	behaviors: [
 		D2L.PolymerBehaviors.Rubric.EntityBehavior,
 		D2L.PolymerBehaviors.Siren.SirenActionBehavior,

--- a/editor/d2l-rubric-editor.js
+++ b/editor/d2l-rubric-editor.js
@@ -492,9 +492,6 @@ Polymer({
 		'd2l-siren-entity-save-error': '_onEntitySave',
 		'd2l-siren-entity-save-end': '_onEntitySave'
 	},
-	observers: [
-		'_onEntityChanged(entity)'
-	],
 	ready: function() {
 		this.addEventListener('d2l-rubric-editor-save-error', this._handleSaveError.bind(this));
 

--- a/editor/d2l-rubric-level-editor.js
+++ b/editor/d2l-rubric-level-editor.js
@@ -148,9 +148,6 @@ Polymer({
 			computed: '_computeUsesPercentage(entity)'
 		}
 	},
-	observers: [
-		'_onEntityChanged(entity)'
-	],
 	behaviors: [
 		D2L.PolymerBehaviors.Rubric.EntityBehavior,
 		D2L.PolymerBehaviors.Siren.SirenActionBehavior,

--- a/editor/d2l-rubric-levels-editor.js
+++ b/editor/d2l-rubric-levels-editor.js
@@ -160,9 +160,6 @@ Polymer({
 		D2L.PolymerBehaviors.Rubric.LocalizeBehavior,
 		IronResizableBehavior
 	],
-	observers: [
-		'_onEntityChanged(entity)',
-	],
 	attached: function() {
 		// Defer the offsetWidth/scrollWidth calculations until after the page has rendered
 		afterNextRender(this, function() {

--- a/editor/d2l-rubric-overall-level-editor.js
+++ b/editor/d2l-rubric-overall-level-editor.js
@@ -128,9 +128,6 @@ Polymer({
 			value: null
 		},
 	},
-	observers: [
-		'_onEntityChanged(entity)'
-	],
 	behaviors: [
 		D2L.PolymerBehaviors.Rubric.EntityBehavior,
 		D2L.PolymerBehaviors.Siren.SirenActionBehavior,

--- a/editor/d2l-rubric-overall-levels-editor.js
+++ b/editor/d2l-rubric-overall-levels-editor.js
@@ -248,9 +248,6 @@ Polymer({
 			// this._notifyResize();
 		}.bind(this), 1);
 	},
-	observers: [
-		'_onEntityChanged(entity)',
-	],
 	_onEntityChanged: function(entity) {
 		if (!entity) {
 			return;

--- a/editor/d2l-rubric-structure-editor.js
+++ b/editor/d2l-rubric-structure-editor.js
@@ -237,10 +237,6 @@ Polymer({
 		'd2l-siren-entity-save-end': '_onEntitySave'
 	},
 
-	observers: [
-		'_onEntityChanged(entity)'
-	],
-
 	ready: function() {
 		this.addEventListener('d2l-siren-entity-error', this._handleError.bind(this));
 		this.addEventListener('d2l-rubric-editor-save-error', this._handleSaveError.bind(this));


### PR DESCRIPTION
The main fix for this bug is in `d2l-rubric-editor`, which sets focus to the rubric name field only when oldEntity is not defined (i.e. first load only). The problem was a duplicate observer was defined on `entity` within that file, as the observer is already defined in EntityBehavior. The second call had oldEntity set to undefined, even when it was just an update like adding a criterion.

I also removed the duplicate observers from other files that had them.