### PR TITLE
US105054 -- Fixed the alignment of the competencies icon when the criterion name takes up multiple lines of text

### DIFF
--- a/d2l-rubric-criteria-group.js
+++ b/d2l-rubric-criteria-group.js
@@ -183,15 +183,15 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-criteria-gro
 									token="[[token]]"
 									outcomes-title-text="[[_getOutcomesTitleText()]]"
 								></d2l-rubric-alignments-indicator>
+								<template is="dom-if" if="[[_showCompetencies(assessmentEntity, criterion, readOnly)]]">
+									<d2l-rubric-competencies-icon
+										competency-names="[[_getCriterionCompetencies(assessmentEntity, criterion)]]"
+									></d2l-rubric-competencies-icon>
+								</template>
 								<div class="criterion-name">
 									<span>
 										[[criterion.properties.name]]
 									</span>
-									<template is="dom-if" if="[[_showCompetencies(assessmentEntity, criterion, readOnly)]]">
-										<d2l-rubric-competencies-icon
-											competency-names="[[_getCriterionCompetencies(assessmentEntity, criterion)]]"
-										></d2l-rubric-competencies-icon>
-									</template>
 								</div>
 								<d2l-button-subtle h-align="text" hidden="[[!_addFeedback(criterion, assessmentResult, criterionNum, _addingFeedback)]]" text="[[localize('addFeedback')]]" on-tap="_handleAddFeedback" data-criterion$="[[criterionNum]]"></d2l-button-subtle>
 							</d2l-td>

--- a/d2l-rubric-criterion-mobile.js
+++ b/d2l-rubric-criterion-mobile.js
@@ -124,7 +124,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-mobile">
 		</style>
 		<rubric-siren-entity href="[[assessmentHref]]" token="[[token]]" entity="{{assessmentEntity}}"></rubric-siren-entity>
 		<div class="criterion-name">
-			<span>[[_name]]</span>
 			<template is="dom-if" if="[[_showCompetencies(assessmentEntity, href, readOnly)]]">
 				<d2l-rubric-competencies-icon
 					competency-names="[[_getCompetencies(assessmentEntity, href)]]"
@@ -138,6 +137,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-mobile">
 				outcomes-title-text="[[_getOutcomesTitleText()]]"
 				mobile
 			></d2l-rubric-alignments-indicator>
+			<span>[[_name]]</span>
 		</div>
 		<d2l-rubric-levels-mobile href="[[levelsHref]]" assessment-href="[[assessmentHref]]" token="[[token]]" selected="{{_selected}}" level-entities="{{_levelEntities}}" total="{{_total}}" out-of="[[_outOf]]" score="[[_score]]" assessed-level-href="[[_assessedLevelHref]]" read-only="[[readOnly]]" criterion-cells="[[_criterionCells]]" criterion-href="[[_getSelfLink(entity)]]">
 		</d2l-rubric-levels-mobile>


### PR DESCRIPTION
Simply moving the icon to before the text fixes the issue