### PR TITLE
hide initial feedback editor for holistic rubric

### DIFF
--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -278,8 +278,8 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-criterion-ed
 							</div>
 						</template>
 					</div>
-					<div class="cell criterion-feedback-header">[[localize('initialFeedback')]]</div>
-					<div class="criterion-feedback">
+					<div class="cell criterion-feedback-header" hidden$="[[isHolistic]]">[[localize('initialFeedback')]]</div>
+					<div class="criterion-feedback" hidden$="[[isHolistic]]">
 						<template is="dom-repeat" as="criterionCell" items="[[_getCriterionCells(entity)]]">
 							<div class="cell">
 								<d2l-rubric-feedback-editor key-link-rels="[[_getCellKeyRels()]]" href="[[_getSelfLink(criterionCell)]]" token="[[token]]" aria-label-langterm="criterionFeedbackAriaLabel" criterion-name="[[entity.properties.name]]" rich-text-enabled="[[richTextEnabled]]">

--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -278,15 +278,17 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-criterion-ed
 							</div>
 						</template>
 					</div>
-					<div class="cell criterion-feedback-header" hidden$="[[isHolistic]]">[[localize('initialFeedback')]]</div>
-					<div class="criterion-feedback" hidden$="[[isHolistic]]">
-						<template is="dom-repeat" as="criterionCell" items="[[_getCriterionCells(entity)]]">
-							<div class="cell">
-								<d2l-rubric-feedback-editor key-link-rels="[[_getCellKeyRels()]]" href="[[_getSelfLink(criterionCell)]]" token="[[token]]" aria-label-langterm="criterionFeedbackAriaLabel" criterion-name="[[entity.properties.name]]" rich-text-enabled="[[richTextEnabled]]">
-								</d2l-rubric-feedback-editor>
-							</div>
-						</template>
-					</div>
+					<template is="dom-if" if="[[!isHolistic]]" restamp>
+						<div class="cell criterion-feedback-header">[[localize('initialFeedback')]]</div>
+						<div class="criterion-feedback">
+							<template is="dom-repeat" as="criterionCell" items="[[_getCriterionCells(entity)]]">
+								<div class="cell">
+									<d2l-rubric-feedback-editor key-link-rels="[[_getCellKeyRels()]]" href="[[_getSelfLink(criterionCell)]]" token="[[token]]" aria-label-langterm="criterionFeedbackAriaLabel" criterion-name="[[entity.properties.name]]" rich-text-enabled="[[richTextEnabled]]">
+									</d2l-rubric-feedback-editor>
+								</div>
+							</template>
+						</div>
+					</template>
 				</div>
 				<div text-only$="[[!_hasOutOf]]" class="cell col-last out-of" hidden$="[[isHolistic]]">
 					<span hidden="[[!_hasOutOf]]">


### PR DESCRIPTION
Steps to Reproduce:
- In the updated rubrics create experience, create a holistic rubric with some initial feedback
- Using the updated rubrics grading experience, use that rubric to assess an activity
- Note that the initial feedback doesn't show up anywhere, and that it is not possible to leave any other feedback on the rubric

Expected Behaviour: It should not be possible to define initial feedback for the levels of a holistic rubric

Actual Behaviour: Initial feedback can be defined for the levels of a holistic rubric but it doesn't show up anywhere.