### PR TITLE
fixing rubric editor not saving properly when input is in focus

### DIFF
--- a/build/lang/ar.js
+++ b/build/lang/ar.js
@@ -136,5 +136,5 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangArBehavior = {
 		'totalScoreAriaLabel': 'تشمل آلية التقييم مجموع درجات يساوي {value} من النقاط.',
 		'totalScoreLabel': 'مجموع درجات آلية التقييم',
 		'makeRubricAvailableHeader': 'Make rubric available to'
-}
+	}
 };

--- a/build/lang/de.js
+++ b/build/lang/de.js
@@ -136,5 +136,5 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangDeBehavior = {
 		'totalScoreAriaLabel': 'Das Bewertungsschema hat eine maximale Punktzahl von {value}.',
 		'totalScoreLabel': 'Gesamtpunktzahl Bewertungsschema',
 		'makeRubricAvailableHeader': 'Make rubric available to'
-}
+	}
 };

--- a/build/lang/en.js
+++ b/build/lang/en.js
@@ -136,5 +136,5 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangEnBehavior = {
 		'descriptionReadOnlyPlaceholder': 'No description',
 		'groupNameSaveFailed': 'Saving criteria group name failed',
 		'makeRubricAvailableHeader': 'Make rubric available to'
-}
+	}
 };

--- a/build/lang/es.js
+++ b/build/lang/es.js
@@ -136,5 +136,5 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangEsBehavior = {
 		'totalScoreAriaLabel': 'La rúbrica tiene una puntuación total de {value} puntos.',
 		'totalScoreLabel': 'Puntuación total según la rúbrica',
 		'makeRubricAvailableHeader': 'Make rubric available to'
-}
+	}
 };

--- a/build/lang/fr.js
+++ b/build/lang/fr.js
@@ -136,5 +136,5 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangFrBehavior = {
 		'totalScoreAriaLabel': 'La grille d’évaluation compte pour la note totale de {value} points.',
 		'totalScoreLabel': 'Note finale de la grille d’évaluation',
 		'makeRubricAvailableHeader': 'Make rubric available to'
-}
+	}
 };

--- a/build/lang/ja.js
+++ b/build/lang/ja.js
@@ -136,5 +136,5 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangJaBehavior = {
 		'totalScoreAriaLabel': '注釈は最大スコア合計 {value} ポイントです。',
 		'totalScoreLabel': '注釈の合計スコア',
 		'makeRubricAvailableHeader': 'Make rubric available to'
-}
+	}
 };

--- a/build/lang/ko.js
+++ b/build/lang/ko.js
@@ -136,5 +136,5 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangKoBehavior = {
 		'totalScoreAriaLabel': '루브릭이 총 {value}점의 점수에서 벗어났습니다.',
 		'totalScoreLabel': '루브릭 총점',
 		'makeRubricAvailableHeader': 'Make rubric available to'
-}
+	}
 };

--- a/build/lang/nl.js
+++ b/build/lang/nl.js
@@ -136,5 +136,5 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangNlBehavior = {
 		'totalScoreAriaLabel': 'De rubric is gebaseerd op een totale score van {value} punten.',
 		'totalScoreLabel': 'Rubric-totaalscore',
 		'makeRubricAvailableHeader': 'Make rubric available to'
-}
+	}
 };

--- a/build/lang/pt.js
+++ b/build/lang/pt.js
@@ -136,5 +136,5 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangPtBehavior = {
 		'totalScoreAriaLabel': 'A rubrica refere-se à pontuação total máxima de {value} pontos.',
 		'totalScoreLabel': 'Pontuação total da rubrica',
 		'makeRubricAvailableHeader': 'Make rubric available to'
-}
+	}
 };

--- a/build/lang/sv.js
+++ b/build/lang/sv.js
@@ -136,5 +136,5 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangSvBehavior = {
 		'totalScoreAriaLabel': 'Rubriceringen är av totalt {value} poäng.',
 		'totalScoreLabel': 'Totala rubriceringspoäng',
 		'makeRubricAvailableHeader': 'Make rubric available to'
-}
+	}
 };

--- a/build/lang/tr.js
+++ b/build/lang/tr.js
@@ -136,5 +136,5 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangTrBehavior = {
 		'totalScoreAriaLabel': 'Rubrik, toplam {value} puandan oluşur.',
 		'totalScoreLabel': 'Rubrik Toplam Puan',
 		'makeRubricAvailableHeader': 'Make rubric available to'
-}
+	}
 };

--- a/build/lang/zh-tw.js
+++ b/build/lang/zh-tw.js
@@ -136,5 +136,5 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangZhTwBehavior = {
 		'totalScoreAriaLabel': '量規超出總分 ({value} 分)。',
 		'totalScoreLabel': '量規總分數',
 		'makeRubricAvailableHeader': 'Make rubric available to'
-}
+	}
 };

--- a/build/lang/zh.js
+++ b/build/lang/zh.js
@@ -136,5 +136,5 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangZhBehavior = {
 		'totalScoreAriaLabel': '量规超出了总分数值 {value}。',
 		'totalScoreLabel': '量规总分',
 		'makeRubricAvailableHeader': 'Make rubric available to'
-}
+	}
 };

--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -261,7 +261,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-criterion-ed
 		<div style="display:flex; flex-direction:column;">
 			<div style="display:flex">
 				<div class="cell col-first criterion-name" hidden$="[[isHolistic]]">
-					<d2l-input-textarea id="name" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('criterionNameAriaLabel')]]" disabled="[[!_canEdit]]" value="[[entity.properties.name]]" placeholder="[[_getNamePlaceholder(localize, displayNamePlaceholder)]]" on-change="_saveName">
+					<d2l-input-textarea id="name" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('criterionNameAriaLabel')]]" disabled="[[!_canEdit]]" value="[[entity.properties.name]]" placeholder="[[_getNamePlaceholder(localize, displayNamePlaceholder)]]" on-change="_saveName" on-input="_saveName">
 					</d2l-input-textarea>
 					<d2l-button-subtle id= "browseOutcomesButton" hidden$="[[_hideBrowseOutcomesButton]]" type="button" on-tap= "_showBrowseOutcomes" text="[[outcomesTitle]]"></d2l-button-subtle>
 					<template is="dom-if" if="[[_nameInvalid]]">

--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -298,7 +298,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-criterion-ed
 							</div>
 						</template>
 						<template is="dom-if" if="[[_outOfIsEditable]]">
-							/ <d2l-input-text id="out-of-textbox" on-change="_saveOutOf" value="[[_outOf]]" aria-invalid="[[isAriaInvalid(_outOfInvalid)]]" aria-label$="[[localize('criterionOutOf', 'name', entity.properties.name, 'value', _outOf)]]" prevent-submit="">
+							/ <d2l-input-text id="out-of-textbox" on-change="_saveOutOf" on-input="_saveOutOfOnInput" value="[[_outOf]]" aria-invalid="[[isAriaInvalid(_outOfInvalid)]]" aria-label$="[[localize('criterionOutOf', 'name', entity.properties.name, 'value', _outOf)]]" prevent-submit="">
 							</d2l-input-text>
 							<template is="dom-if" if="[[_outOfInvalid]]">
 								<d2l-tooltip id="out-of-bubble" class="is-error" for="out-of-textbox" position="bottom">
@@ -518,6 +518,27 @@ Polymer({
 				this.handleValidationError('out-of-bubble', '_outOfInvalid', 'pointsSaveFailed', err);
 			}.bind(this));
 		}
+	},
+
+	_saveOutOfOnInput: function(e) {
+		var action = this.entity.getActionByName('update-outof');
+		var value = e.target.value;
+		this.debounce('input', function() {
+			if (action) {
+				if (!value.trim()) {
+					this.handleValidationError('out-of-bubble', '_outOfInvalid', 'pointsAreRequired');
+					return;
+				} else {
+					this.toggleBubble('_outOfInvalid', false, 'out-of-bubble');
+				}
+				var fields = [{'name': 'outOf', 'value': value}];
+				this.performSirenAction(action, fields).then(function() {
+					this.fire('d2l-rubric-criterion-saved');
+				}.bind(this)).catch(function(err) {
+					this.handleValidationError('out-of-bubble', '_outOfInvalid', 'pointsSaveFailed', err);
+				}.bind(this));
+			}
+		}.bind(this), 500);
 	},
 
 	_canEditCriterion: function(entity) {

--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -261,7 +261,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-criterion-ed
 		<div style="display:flex; flex-direction:column;">
 			<div style="display:flex">
 				<div class="cell col-first criterion-name" hidden$="[[isHolistic]]">
-					<d2l-input-textarea id="name" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('criterionNameAriaLabel')]]" disabled="[[!_canEdit]]" value="[[entity.properties.name]]" placeholder="[[_getNamePlaceholder(localize, displayNamePlaceholder)]]" on-change="_saveName" on-input="_saveName">
+					<d2l-input-textarea id="name" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('criterionNameAriaLabel')]]" disabled="[[!_canEdit]]" value="[[entity.properties.name]]" placeholder="[[_getNamePlaceholder(localize, displayNamePlaceholder)]]" on-input="_saveName">
 					</d2l-input-textarea>
 					<d2l-button-subtle id= "browseOutcomesButton" hidden$="[[_hideBrowseOutcomesButton]]" type="button" on-tap= "_showBrowseOutcomes" text="[[outcomesTitle]]"></d2l-button-subtle>
 					<template is="dom-if" if="[[_nameInvalid]]">
@@ -465,20 +465,23 @@ Polymer({
 
 	_saveName: function(e) {
 		var action = this.entity.getActionByName('update');
-		if (action) {
-			if (this._nameRequired && !e.target.value.trim()) {
-				this.handleValidationError('criterion-name-bubble', '_nameInvalid', 'nameIsRequired');
-				return;
-			} else {
-				this.toggleBubble('_nameInvalid', false, 'criterion-name-bubble');
+		var value = e.target.value;
+		this.debounce('input', function() {
+			if (action) {
+				if (this._nameRequired && !value.trim()) {
+					this.handleValidationError('criterion-name-bubble', '_nameInvalid', 'nameIsRequired');
+					return;
+				} else {
+					this.toggleBubble('_nameInvalid', false, 'criterion-name-bubble');
+				}
+				var fields = [{ 'name': 'name', 'value': value }];
+				this.performSirenAction(action, fields).then(function() {
+					this.fire('d2l-rubric-criterion-saved');
+				}.bind(this)).catch(function(err) {
+					this.handleValidationError('criterion-name-bubble', '_nameInvalid', 'nameSaveFailed', err);
+				}.bind(this));
 			}
-			var fields = [{ 'name': 'name', 'value': e.target.value }];
-			this.performSirenAction(action, fields).then(function() {
-				this.fire('d2l-rubric-criterion-saved');
-			}.bind(this)).catch(function(err) {
-				this.handleValidationError('criterion-name-bubble', '_nameInvalid', 'nameSaveFailed', err);
-			}.bind(this));
-		}
+		}.bind(this), 500);
 	},
 
 	_saveOutOf: function(e) {

--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -261,7 +261,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-criterion-ed
 		<div style="display:flex; flex-direction:column;">
 			<div style="display:flex">
 				<div class="cell col-first criterion-name" hidden$="[[isHolistic]]">
-					<d2l-input-textarea id="name" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('criterionNameAriaLabel')]]" disabled="[[!_canEdit]]" value="[[entity.properties.name]]" placeholder="[[_getNamePlaceholder(localize, displayNamePlaceholder)]]" on-input="_saveName">
+					<d2l-input-textarea id="name" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('criterionNameAriaLabel')]]" disabled="[[!_canEdit]]" value="[[entity.properties.name]]" placeholder="[[_getNamePlaceholder(localize, displayNamePlaceholder)]]" on-change="_saveName" on-input="_saveNameOnInput">
 					</d2l-input-textarea>
 					<d2l-button-subtle id= "browseOutcomesButton" hidden$="[[_hideBrowseOutcomesButton]]" type="button" on-tap= "_showBrowseOutcomes" text="[[outcomesTitle]]"></d2l-button-subtle>
 					<template is="dom-if" if="[[_nameInvalid]]">
@@ -464,6 +464,24 @@ Polymer({
 	},
 
 	_saveName: function(e) {
+		var action = this.entity.getActionByName('update');
+		if (action) {
+			if (this._nameRequired && !e.target.value.trim()) {
+				this.handleValidationError('criterion-name-bubble', '_nameInvalid', 'nameIsRequired');
+				return;
+			} else {
+				this.toggleBubble('_nameInvalid', false, 'criterion-name-bubble');
+			}
+			var fields = [{ 'name': 'name', 'value': e.target.value }];
+			this.performSirenAction(action, fields).then(function() {
+				this.fire('d2l-rubric-criterion-saved');
+			}.bind(this)).catch(function(err) {
+				this.handleValidationError('criterion-name-bubble', '_nameInvalid', 'nameSaveFailed', err);
+			}.bind(this));
+		}
+	},
+
+	_saveNameOnInput: function(e) {
 		var action = this.entity.getActionByName('update');
 		var value = e.target.value;
 		this.debounce('input', function() {

--- a/editor/d2l-rubric-editor.js
+++ b/editor/d2l-rubric-editor.js
@@ -251,7 +251,8 @@ const $_documentContainer = html `
 				<d2l-input-text
 					id="rubric-name"
 					value="[[_rubricName]]"
-					on-input="_saveName"
+					on-change="_saveName"
+					on-input="_saveNameOnInput"
 					aria-invalid="[[isAriaInvalid(_nameInvalid)]]"
 					aria-label$="[[localize('name')]]"
 					disabled="[[!_canEditName]]"
@@ -688,6 +689,22 @@ Polymer({
 
 	},
 	_saveName: function(e) {
+		var action = this.entity.getActionByName('update-name');
+		if (action) {
+			if (this._nameRequired && !e.target.value.trim()) {
+				this.handleValidationError('name-bubble', '_nameInvalid', 'nameIsRequired');
+			} else {
+				this.toggleBubble('_nameInvalid', false, 'name-bubble');
+				var fields = [{ 'name': 'name', 'value': e.target.value }];
+				this.performSirenAction(action, fields).then(function() {
+					this.fire('d2l-rubric-name-saved');
+				}.bind(this)).catch(function(err) {
+					this.handleValidationError('name-bubble', '_nameInvalid', 'nameSaveFailed', err);
+				}.bind(this));
+			}
+		}
+	},
+	_saveNameOnInput: function(e) {
 		var action = this.entity.getActionByName('update-name');
 		var value = e.target.value;
 		this.debounce('input', function() {

--- a/editor/d2l-rubric-editor.js
+++ b/editor/d2l-rubric-editor.js
@@ -251,7 +251,6 @@ const $_documentContainer = html `
 				<d2l-input-text
 					id="rubric-name"
 					value="[[_rubricName]]"
-					on-change="_saveName"
 					on-input="_saveName"
 					aria-invalid="[[isAriaInvalid(_nameInvalid)]]"
 					aria-label$="[[localize('name')]]"
@@ -690,19 +689,22 @@ Polymer({
 	},
 	_saveName: function(e) {
 		var action = this.entity.getActionByName('update-name');
-		if (action) {
-			if (this._nameRequired && !e.target.value.trim()) {
-				this.handleValidationError('name-bubble', '_nameInvalid', 'nameIsRequired');
-			} else {
-				this.toggleBubble('_nameInvalid', false, 'name-bubble');
-				var fields = [{ 'name': 'name', 'value': e.target.value }];
-				this.performSirenAction(action, fields).then(function() {
-					this.fire('d2l-rubric-name-saved');
-				}.bind(this)).catch(function(err) {
-					this.handleValidationError('name-bubble', '_nameInvalid', 'nameSaveFailed', err);
-				}.bind(this));
+		var value = e.target.value;
+		this.debounce('input', function() {
+			if (action) {
+				if (this._nameRequired && !value.trim()) {
+					this.handleValidationError('name-bubble', '_nameInvalid', 'nameIsRequired');
+				} else {
+					this.toggleBubble('_nameInvalid', false, 'name-bubble');
+					var fields = [{ 'name': 'name', 'value': value }];
+					this.performSirenAction(action, fields).then(function() {
+						this.fire('d2l-rubric-name-saved');
+					}.bind(this)).catch(function(err) {
+						this.handleValidationError('name-bubble', '_nameInvalid', 'nameSaveFailed', err);
+					}.bind(this));
+				}
 			}
-		}
+		}.bind(this), 500);
 	},
 	_onEntitySave: function(e) {
 		this.$$('#rubric-header').onEntitySave(e);

--- a/editor/d2l-rubric-editor.js
+++ b/editor/d2l-rubric-editor.js
@@ -200,7 +200,7 @@ const $_documentContainer = html `
 				margin-top: 8px;
 				margin-bottom: 8px;
 			}
-			#description-html-container > s-html::shadow > * {
+			#description-html-container > s-html::shadow > * { // eslint-disable-line
 				margin: 0px;
 			}
 			#rubric-description-container {

--- a/editor/d2l-rubric-editor.js
+++ b/editor/d2l-rubric-editor.js
@@ -530,7 +530,8 @@ Polymer({
 		'd2l-siren-entity-save-error': '_onEntitySave',
 		'd2l-siren-entity-save-end': '_onEntitySave'
 	},
-	_computeCanShare(entity) {
+
+	_computeCanShare: function(entity) {
 		return entity && entity.hasLinkByRel('https://organizations.api.brightspace.com/rels/orgunit-availability-set');
 	},
 	ready: function() {
@@ -551,7 +552,7 @@ Polymer({
 				}
 			});
 		}
-		
+
 		var elem = dom(this.root).querySelector('#description-html-content');
 		if (elem && elem.shadowRoot) {
 			elem.shadowRoot.querySelectorAll('*').forEach(el => {

--- a/editor/d2l-rubric-editor.js
+++ b/editor/d2l-rubric-editor.js
@@ -255,6 +255,7 @@ const $_documentContainer = html `
 					id="rubric-name"
 					value="[[_rubricName]]"
 					on-change="_saveName"
+					on-input="_saveName"
 					aria-invalid="[[isAriaInvalid(_nameInvalid)]]"
 					aria-label$="[[localize('name')]]"
 					disabled="[[!_canEditName]]"

--- a/editor/d2l-rubric-editor.js
+++ b/editor/d2l-rubric-editor.js
@@ -200,9 +200,6 @@ const $_documentContainer = html `
 				margin-top: 8px;
 				margin-bottom: 8px;
 			}
-			#description-html-container > s-html::shadow > * { // eslint-disable-line
-				margin: 0px;
-			}
 			#rubric-description-container {
 				margin-top: 2.3rem;
 			}
@@ -313,7 +310,7 @@ const $_documentContainer = html `
 							<label for="rubric-description">[[localize('descriptionReadOnlyMode')]]</label>
 							<template is="dom-if" if="[[richTextEnabled]]">
 								<div id="description-html-container">
-									<s-html html$="[[_getReadOnlyDescription(_rubricDescription, 1)]]"></s-html>
+									<s-html id="description-html-content" html$="[[_getReadOnlyDescription(_rubricDescription, 1)]]"></s-html>
 								</div>
 							</template>
 							<template is="dom-if" if="[[!richTextEnabled]]">
@@ -552,6 +549,13 @@ Polymer({
 					event.stopPropagation();
 					event.preventDefault();
 				}
+			});
+		}
+		
+		var elem = dom(this.root).querySelector('#description-html-content');
+		if (elem && elem.shadowRoot) {
+			elem.shadowRoot.querySelectorAll('*').forEach(el => {
+				el.style.margin = 0;
 			});
 		}
 	},

--- a/editor/d2l-rubric-level-editor.js
+++ b/editor/d2l-rubric-level-editor.js
@@ -69,11 +69,11 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-level-editor">
 			}
 		</style>
 
-		<d2l-input-text id="level-name" value="[[entity.properties.name]]" on-change="_saveName" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('levelName')]]" disabled="[[!_canEditName]]" prevent-submit="">
+		<d2l-input-text id="level-name" value="[[entity.properties.name]]" on-change="_saveName" on-input="_saveName" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('levelName')]]" disabled="[[!_canEditName]]" prevent-submit="">
 		</d2l-input-text>
 		<div class="operations" nopoints$="[[!_showPoints]]">
 			<div class="points" hidden="[[!_showPoints]]" alt-percent-format$="[[_showAltPercentFormat(percentageFormatAlternate,_usesPercentage)]]">
-				<d2l-input-text id="level-points" value="[[entity.properties.points]]" on-change="_savePoints" aria-invalid="[[isAriaInvalid(_pointsInvalid)]]" aria-label$="[[localize('levelPoints')]]" disabled="[[!_canEditPoints]]" size="1" prevent-submit="">
+				<d2l-input-text id="level-points" value="[[entity.properties.points]]" on-change="_savePoints" on-input="_savePoints" aria-invalid="[[isAriaInvalid(_pointsInvalid)]]" aria-label$="[[localize('levelPoints')]]" disabled="[[!_canEditPoints]]" size="1" prevent-submit="">
 				</d2l-input-text>
 				<div>[[_getPointsUnitText(entity)]]</div>
 			</div>

--- a/editor/d2l-rubric-level-editor.js
+++ b/editor/d2l-rubric-level-editor.js
@@ -69,11 +69,11 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-level-editor">
 			}
 		</style>
 
-		<d2l-input-text id="level-name" value="[[entity.properties.name]]" on-change="_saveName" on-input="_saveName" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('levelName')]]" disabled="[[!_canEditName]]" prevent-submit="">
+		<d2l-input-text id="level-name" value="[[entity.properties.name]]" on-input="_saveName" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('levelName')]]" disabled="[[!_canEditName]]" prevent-submit="">
 		</d2l-input-text>
 		<div class="operations" nopoints$="[[!_showPoints]]">
 			<div class="points" hidden="[[!_showPoints]]" alt-percent-format$="[[_showAltPercentFormat(percentageFormatAlternate,_usesPercentage)]]">
-				<d2l-input-text id="level-points" value="[[entity.properties.points]]" on-change="_savePoints" on-input="_savePoints" aria-invalid="[[isAriaInvalid(_pointsInvalid)]]" aria-label$="[[localize('levelPoints')]]" disabled="[[!_canEditPoints]]" size="1" prevent-submit="">
+				<d2l-input-text id="level-points" value="[[entity.properties.points]]" on-input="_savePoints" aria-invalid="[[isAriaInvalid(_pointsInvalid)]]" aria-label$="[[localize('levelPoints')]]" disabled="[[!_canEditPoints]]" size="1" prevent-submit="">
 				</d2l-input-text>
 				<div>[[_getPointsUnitText(entity)]]</div>
 			</div>
@@ -209,43 +209,49 @@ Polymer({
 	},
 	_saveName: function(e) {
 		var action = this.entity.getActionByName('update-name');
-		if (action) {
-			if (this._nameRequired && !e.target.value.trim()) {
-				this.handleValidationError('level-name-bubble', '_nameInvalid', 'nameIsRequired');
-			} else {
-				this.toggleBubble('_nameInvalid', false, 'level-name-bubble');
-				var fields = [{'name':'name', 'value':e.target.value}];
-				this.performSirenAction(action, fields).then(function() {
-					this.fire('d2l-rubric-level-saved');
-				}.bind(this)).catch(function(err) {
-					this.handleValidationError('level-name-bubble', '_nameInvalid', 'nameSaveFailed', err);
-				}.bind(this));
+		var value = e.target.value;
+		this.debounce('input', function() {
+			if (action) {
+				if (this._nameRequired && !value.trim()) {
+					this.handleValidationError('level-name-bubble', '_nameInvalid', 'nameIsRequired');
+				} else {
+					this.toggleBubble('_nameInvalid', false, 'level-name-bubble');
+					var fields = [{'name': 'name', 'value': value}];
+					this.performSirenAction(action, fields).then(function() {
+						this.fire('d2l-rubric-level-saved');
+					}.bind(this)).catch(function(err) {
+						this.handleValidationError('level-name-bubble', '_nameInvalid', 'nameSaveFailed', err);
+					}.bind(this));
+				}
 			}
-		}
+		}.bind(this), 500);
 	},
 	_savePoints: function(e) {
 		var action = this.entity.getActionByName('update-points');
-		if (action) {
-			if (this._pointsRequired && !e.target.value.trim()) {
-				if (this._usesPercentage) {
-					this.handleValidationError('points-bubble', '_pointsInvalid', 'rangeStartRequired');
-				} else {
-					this.handleValidationError('points-bubble', '_pointsInvalid', 'pointsAreRequired');
-				}
-			} else {
-				this.toggleBubble('_pointsInvalid', false, 'points-bubble');
-				var fields = [{'name':'points', 'value':e.target.value}];
-				this.performSirenAction(action, fields).then(function() {
-					this.fire('d2l-rubric-level-points-saved');
-				}.bind(this)).catch(function(err) {
+		var value = e.target.value;
+		this.debounce('input', function() {
+			if (action) {
+				if (this._pointsRequired && !value.trim()) {
 					if (this._usesPercentage) {
-						this.handleValidationError('points-bubble', '_pointsInvalid', 'rangeStartInvalid', err);
+						this.handleValidationError('points-bubble', '_pointsInvalid', 'rangeStartRequired');
 					} else {
-						this.handleValidationError('points-bubble', '_pointsInvalid', 'pointsSaveFailed', err);
+						this.handleValidationError('points-bubble', '_pointsInvalid', 'pointsAreRequired');
 					}
-				}.bind(this));
+				} else {
+					this.toggleBubble('_pointsInvalid', false, 'points-bubble');
+					var fields = [{'name': 'points', 'value': value}];
+					this.performSirenAction(action, fields).then(function() {
+						this.fire('d2l-rubric-level-points-saved');
+					}.bind(this)).catch(function(err) {
+						if (this._usesPercentage) {
+							this.handleValidationError('points-bubble', '_pointsInvalid', 'rangeStartInvalid', err);
+						} else {
+							this.handleValidationError('points-bubble', '_pointsInvalid', 'pointsSaveFailed', err);
+						}
+					}.bind(this));
+				}
 			}
-		}
+		}.bind(this), 500);
 	},
 	_canDeleteLevel: function(entity) {
 		return entity && entity.hasActionByName('delete');

--- a/editor/d2l-rubric-overall-level-editor.js
+++ b/editor/d2l-rubric-overall-level-editor.js
@@ -56,11 +56,11 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-overall-leve
 			}
 		</style>
 
-		<d2l-input-text id="overall-level-name" value="[[entity.properties.name]]" on-input="_saveName" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('overallLevelName')]]" disabled="[[!_canEditName]]" prevent-submit="">
+		<d2l-input-text id="overall-level-name" value="[[entity.properties.name]]" on-change="_saveName" on-input="_saveNameOnInput" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('overallLevelName')]]" disabled="[[!_canEditName]]" prevent-submit="">
 		</d2l-input-text>
 		<div class="operations" text-only$="[[!_hasRangeStart]]">
 			<div class="points" hidden="[[!_hasRangeStart]]">
-				<d2l-input-text id="range-start" value="[[entity.properties.rangeStart]]" on-input="_saveRangeStart" aria-invalid="[[isAriaInvalid(_rangeStartInvalid)]]" aria-label$="[[localize('overallLevelRangeStart')]]" disabled="[[!_canEditRangeStart]]" size="1" prevent-submit="">
+				<d2l-input-text id="range-start" value="[[entity.properties.rangeStart]]" on-change="_saveRangeStart" on-input="_saveRangeStartOnInput" aria-invalid="[[isAriaInvalid(_rangeStartInvalid)]]" aria-label$="[[localize('overallLevelRangeStart')]]" disabled="[[!_canEditRangeStart]]" size="1" prevent-submit="">
 				</d2l-input-text>
 				<div>[[localize('rangeStartOrMore')]]</div>
 			</div>
@@ -173,6 +173,38 @@ Polymer({
 	},
 	_saveName: function(e) {
 		var action = this.entity.getActionByName('update-name');
+		if (action) {
+			if (this._nameRequired && !e.target.value.trim()) {
+				this.handleValidationError('overall-level-name-bubble', '_nameInvalid', 'nameIsRequired');
+			} else {
+				this.toggleBubble('_nameInvalid', false, 'overall-level-name-bubble');
+				var fields = [{ 'name': 'name', 'value': e.target.value }];
+				this.performSirenAction(action, fields).then(function() {
+					this.fire('d2l-rubric-overall-level-saved');
+				}.bind(this)).catch(function(err) {
+					this.handleValidationError('overall-level-name-bubble', '_nameInvalid', 'nameSaveFailed', err);
+				}.bind(this));
+			}
+		}
+	},
+	_saveRangeStart: function(e) {
+		var action = this.entity.getActionByName('update-range-start');
+		if (action) {
+			if (this._rangeStartRequired && !e.target.value.trim()) {
+				this.handleValidationError('range-start-bubble', '_rangeStartInvalid', 'rangeStartRequired');
+			} else {
+				this.toggleBubble('_rangeStartInvalid', false, 'range-start-bubble');
+				var fields = [{'name':'rangeStart', 'value':e.target.value}];
+				this.performSirenAction(action, fields).then(function() {
+					this.fire('d2l-rubric-overall-level-range-start-saved');
+				}.bind(this)).catch(function(err) {
+					this.handleValidationError('range-start-bubble', '_rangeStartInvalid', 'rangeStartInvalid', err);
+				}.bind(this));
+			}
+		}
+	},
+	_saveNameOnInput: function(e) {
+		var action = this.entity.getActionByName('update-name');
 		var value = e.target.value;
 		this.debounce('input', function() {
 			if (action) {
@@ -190,7 +222,7 @@ Polymer({
 			}
 		}.bind(this), 500);
 	},
-	_saveRangeStart: function(e) {
+	_saveRangeStartOnInput: function(e) {
 		var action = this.entity.getActionByName('update-range-start');
 		var value = e.target.value;
 		this.debounce('input', function() {

--- a/editor/d2l-rubric-overall-level-editor.js
+++ b/editor/d2l-rubric-overall-level-editor.js
@@ -56,11 +56,11 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-overall-leve
 			}
 		</style>
 
-		<d2l-input-text id="overall-level-name" value="[[entity.properties.name]]" on-change="_saveName" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('overallLevelName')]]" disabled="[[!_canEditName]]" prevent-submit="">
+		<d2l-input-text id="overall-level-name" value="[[entity.properties.name]]" on-change="_saveName" on-input="_saveName" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('overallLevelName')]]" disabled="[[!_canEditName]]" prevent-submit="">
 		</d2l-input-text>
 		<div class="operations" text-only$="[[!_hasRangeStart]]">
 			<div class="points" hidden="[[!_hasRangeStart]]">
-				<d2l-input-text id="range-start" value="[[entity.properties.rangeStart]]" on-change="_saveRangeStart" aria-invalid="[[isAriaInvalid(_rangeStartInvalid)]]" aria-label$="[[localize('overallLevelRangeStart')]]" disabled="[[!_canEditRangeStart]]" size="1" prevent-submit="">
+				<d2l-input-text id="range-start" value="[[entity.properties.rangeStart]]" on-change="_saveRangeStart" on-input="_saveRangeStart" aria-invalid="[[isAriaInvalid(_rangeStartInvalid)]]" aria-label$="[[localize('overallLevelRangeStart')]]" disabled="[[!_canEditRangeStart]]" size="1" prevent-submit="">
 				</d2l-input-text>
 				<div>[[localize('rangeStartOrMore')]]</div>
 			</div>

--- a/editor/d2l-rubric-overall-level-editor.js
+++ b/editor/d2l-rubric-overall-level-editor.js
@@ -56,11 +56,11 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-overall-leve
 			}
 		</style>
 
-		<d2l-input-text id="overall-level-name" value="[[entity.properties.name]]" on-change="_saveName" on-input="_saveName" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('overallLevelName')]]" disabled="[[!_canEditName]]" prevent-submit="">
+		<d2l-input-text id="overall-level-name" value="[[entity.properties.name]]" on-input="_saveName" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('overallLevelName')]]" disabled="[[!_canEditName]]" prevent-submit="">
 		</d2l-input-text>
 		<div class="operations" text-only$="[[!_hasRangeStart]]">
 			<div class="points" hidden="[[!_hasRangeStart]]">
-				<d2l-input-text id="range-start" value="[[entity.properties.rangeStart]]" on-change="_saveRangeStart" on-input="_saveRangeStart" aria-invalid="[[isAriaInvalid(_rangeStartInvalid)]]" aria-label$="[[localize('overallLevelRangeStart')]]" disabled="[[!_canEditRangeStart]]" size="1" prevent-submit="">
+				<d2l-input-text id="range-start" value="[[entity.properties.rangeStart]]" on-input="_saveRangeStart" aria-invalid="[[isAriaInvalid(_rangeStartInvalid)]]" aria-label$="[[localize('overallLevelRangeStart')]]" disabled="[[!_canEditRangeStart]]" size="1" prevent-submit="">
 				</d2l-input-text>
 				<div>[[localize('rangeStartOrMore')]]</div>
 			</div>
@@ -173,35 +173,41 @@ Polymer({
 	},
 	_saveName: function(e) {
 		var action = this.entity.getActionByName('update-name');
-		if (action) {
-			if (this._nameRequired && !e.target.value.trim()) {
-				this.handleValidationError('overall-level-name-bubble', '_nameInvalid', 'nameIsRequired');
-			} else {
-				this.toggleBubble('_nameInvalid', false, 'overall-level-name-bubble');
-				var fields = [{ 'name': 'name', 'value': e.target.value }];
-				this.performSirenAction(action, fields).then(function() {
-					this.fire('d2l-rubric-overall-level-saved');
-				}.bind(this)).catch(function(err) {
-					this.handleValidationError('overall-level-name-bubble', '_nameInvalid', 'nameSaveFailed', err);
-				}.bind(this));
+		var value = e.target.value;
+		this.debounce('input', function() {
+			if (action) {
+				if (this._nameRequired && !value.trim()) {
+					this.handleValidationError('overall-level-name-bubble', '_nameInvalid', 'nameIsRequired');
+				} else {
+					this.toggleBubble('_nameInvalid', false, 'overall-level-name-bubble');
+					var fields = [{'name': 'name', 'value': value}];
+					this.performSirenAction(action, fields).then(function() {
+						this.fire('d2l-rubric-overall-level-saved');
+					}.bind(this)).catch(function(err) {
+						this.handleValidationError('overall-level-name-bubble', '_nameInvalid', 'nameSaveFailed', err);
+					}.bind(this));
+				}
 			}
-		}
+		}.bind(this), 500);
 	},
 	_saveRangeStart: function(e) {
 		var action = this.entity.getActionByName('update-range-start');
-		if (action) {
-			if (this._rangeStartRequired && !e.target.value.trim()) {
-				this.handleValidationError('range-start-bubble', '_rangeStartInvalid', 'rangeStartRequired');
-			} else {
-				this.toggleBubble('_rangeStartInvalid', false, 'range-start-bubble');
-				var fields = [{'name':'rangeStart', 'value':e.target.value}];
-				this.performSirenAction(action, fields).then(function() {
-					this.fire('d2l-rubric-overall-level-range-start-saved');
-				}.bind(this)).catch(function(err) {
-					this.handleValidationError('range-start-bubble', '_rangeStartInvalid', 'rangeStartInvalid', err);
-				}.bind(this));
+		var value = e.target.value;
+		this.debounce('input', function() {
+			if (action) {
+				if (this._rangeStartRequired && !value.trim()) {
+					this.handleValidationError('range-start-bubble', '_rangeStartInvalid', 'rangeStartRequired');
+				} else {
+					this.toggleBubble('_rangeStartInvalid', false, 'range-start-bubble');
+					var fields = [{'name': 'rangeStart', 'value': value}];
+					this.performSirenAction(action, fields).then(function() {
+						this.fire('d2l-rubric-overall-level-range-start-saved');
+					}.bind(this)).catch(function(err) {
+						this.handleValidationError('range-start-bubble', '_rangeStartInvalid', 'rangeStartInvalid', err);
+					}.bind(this));
+				}
 			}
-		}
+		}.bind(this), 500);
 	},
 	_canDeleteLevel: function(entity) {
 		return entity && entity.hasActionByName('delete');

--- a/editor/d2l-rubric-text-editor.js
+++ b/editor/d2l-rubric-text-editor.js
@@ -80,7 +80,7 @@ Polymer({
 			e.detail.content : e.target.value || '';
 		this.fire('change', { value: value });
 	},
-	
+
 	_duringInputChange: function(e) {
 		e.stopPropagation();
 		var value;

--- a/editor/d2l-rubric-text-editor.js
+++ b/editor/d2l-rubric-text-editor.js
@@ -21,10 +21,10 @@ Polymer({
 
 		</style>
 		<template is="dom-if" if="[[!richTextEnabled]]">
-			<d2l-input-textarea id="textEditor" hidden$="[[richTextEnabled]]" aria-invalid="[[ariaInvalid]]" aria-label$="[[ariaLabel]]" disabled="[[disabled]]" value="[[value]]" on-input="_duringInputChange"></d2l-input-textarea>
+			<d2l-input-textarea id="textEditor" hidden$="[[richTextEnabled]]" aria-invalid="[[ariaInvalid]]" aria-label$="[[ariaLabel]]" disabled="[[disabled]]" value="[[value]]" on-change="_onInputChange" on-input="_duringInputChange"></d2l-input-textarea>
 		</template>
 		<template is="dom-if" if="[[richTextEnabled]]">
-			<d2l-rubric-html-editor id="htmlEditor" token="[[token]]" hidden$="[[!richTextEnabled]]" aria-label$="[[ariaLabel]]" invalid="[[_stringIsTrue(ariaInvalid)]]" placeholder="[[placeholder]]" value="[[value]]" key="[[key]]" min-rows="[[minRows]]" max-rows="[[maxRows]]" on-input="_duringInputChange"></d2l-rubric-html-editor>
+			<d2l-rubric-html-editor id="htmlEditor" token="[[token]]" hidden$="[[!richTextEnabled]]" aria-label$="[[ariaLabel]]" invalid="[[_stringIsTrue(ariaInvalid)]]" placeholder="[[placeholder]]" value="[[value]]" key="[[key]]" min-rows="[[minRows]]" max-rows="[[maxRows]]" on-change="_onInputChange" on-input="_duringInputChange"></d2l-rubric-html-editor>
 		</template>
 `,
 
@@ -72,6 +72,13 @@ Polymer({
 
 	_stringIsTrue: function(string) {
 		return string && string === 'true';
+	},
+
+	_onInputChange: function(e) {
+		e.stopPropagation();
+		var value = (e.detail && e.detail.hasOwnProperty('content')) ?
+			e.detail.content : e.target.value || '';
+		this.fire('change', { value: value });
 	},
 
 	_duringInputChange: function(e) {

--- a/editor/d2l-rubric-text-editor.js
+++ b/editor/d2l-rubric-text-editor.js
@@ -21,10 +21,10 @@ Polymer({
 
 		</style>
 		<template is="dom-if" if="[[!richTextEnabled]]">
-			<d2l-input-textarea id="textEditor" hidden$="[[richTextEnabled]]" aria-invalid="[[ariaInvalid]]" aria-label$="[[ariaLabel]]" disabled="[[disabled]]" value="[[value]]" on-change="_onInputChange"></d2l-input-textarea>
+			<d2l-input-textarea id="textEditor" hidden$="[[richTextEnabled]]" aria-invalid="[[ariaInvalid]]" aria-label$="[[ariaLabel]]" disabled="[[disabled]]" value="[[value]]" on-change="_onInputChange" on-input="_duringInputChange"></d2l-input-textarea>
 		</template>
 		<template is="dom-if" if="[[richTextEnabled]]">
-			<d2l-rubric-html-editor id="htmlEditor" token="[[token]]" hidden$="[[!richTextEnabled]]" aria-label$="[[ariaLabel]]" invalid="[[_stringIsTrue(ariaInvalid)]]" placeholder="[[placeholder]]" value="[[value]]" key="[[key]]" min-rows="[[minRows]]" max-rows="[[maxRows]]" on-change="_onInputChange"></d2l-rubric-html-editor>
+			<d2l-rubric-html-editor id="htmlEditor" token="[[token]]" hidden$="[[!richTextEnabled]]" aria-label$="[[ariaLabel]]" invalid="[[_stringIsTrue(ariaInvalid)]]" placeholder="[[placeholder]]" value="[[value]]" key="[[key]]" min-rows="[[minRows]]" max-rows="[[maxRows]]" on-change="_onInputChange" on-input="_duringInputChange"></d2l-rubric-html-editor>
 		</template>
 `,
 
@@ -78,6 +78,18 @@ Polymer({
 		e.stopPropagation();
 		var value = (e.detail && e.detail.hasOwnProperty('content')) ?
 			e.detail.content : e.target.value || '';
+		this.fire('change', { value: value });
+	},
+	
+	_duringInputChange: function(e) {
+		e.stopPropagation();
+		var value;
+		if (this.richTextEnabled) {
+			value = e.target._getContent() ? e.target._getContent() : '';
+		} else {
+			value = (e.detail && e.detail.hasOwnProperty('content')) ?
+				e.detail.content : e.target.value || '';
+		}
 		this.fire('change', { value: value });
 	}
 });

--- a/editor/d2l-rubric-text-editor.js
+++ b/editor/d2l-rubric-text-editor.js
@@ -84,7 +84,6 @@ Polymer({
 				e.detail.content : e.target.value || '';
 		}
 		this.debounce('input', function() {
-			console.log(value);
 			this.fire('change', { value: value });
 		}.bind(this), 500);
 	}

--- a/editor/d2l-rubric-text-editor.js
+++ b/editor/d2l-rubric-text-editor.js
@@ -21,10 +21,10 @@ Polymer({
 
 		</style>
 		<template is="dom-if" if="[[!richTextEnabled]]">
-			<d2l-input-textarea id="textEditor" hidden$="[[richTextEnabled]]" aria-invalid="[[ariaInvalid]]" aria-label$="[[ariaLabel]]" disabled="[[disabled]]" value="[[value]]" on-change="_onInputChange" on-input="_duringInputChange"></d2l-input-textarea>
+			<d2l-input-textarea id="textEditor" hidden$="[[richTextEnabled]]" aria-invalid="[[ariaInvalid]]" aria-label$="[[ariaLabel]]" disabled="[[disabled]]" value="[[value]]" on-input="_duringInputChange"></d2l-input-textarea>
 		</template>
 		<template is="dom-if" if="[[richTextEnabled]]">
-			<d2l-rubric-html-editor id="htmlEditor" token="[[token]]" hidden$="[[!richTextEnabled]]" aria-label$="[[ariaLabel]]" invalid="[[_stringIsTrue(ariaInvalid)]]" placeholder="[[placeholder]]" value="[[value]]" key="[[key]]" min-rows="[[minRows]]" max-rows="[[maxRows]]" on-change="_onInputChange" on-input="_duringInputChange"></d2l-rubric-html-editor>
+			<d2l-rubric-html-editor id="htmlEditor" token="[[token]]" hidden$="[[!richTextEnabled]]" aria-label$="[[ariaLabel]]" invalid="[[_stringIsTrue(ariaInvalid)]]" placeholder="[[placeholder]]" value="[[value]]" key="[[key]]" min-rows="[[minRows]]" max-rows="[[maxRows]]" on-input="_duringInputChange"></d2l-rubric-html-editor>
 		</template>
 `,
 
@@ -74,13 +74,6 @@ Polymer({
 		return string && string === 'true';
 	},
 
-	_onInputChange: function(e) {
-		e.stopPropagation();
-		var value = (e.detail && e.detail.hasOwnProperty('content')) ?
-			e.detail.content : e.target.value || '';
-		this.fire('change', { value: value });
-	},
-
 	_duringInputChange: function(e) {
 		e.stopPropagation();
 		var value;
@@ -90,6 +83,9 @@ Polymer({
 			value = (e.detail && e.detail.hasOwnProperty('content')) ?
 				e.detail.content : e.target.value || '';
 		}
-		this.fire('change', { value: value });
+		this.debounce('input', function() {
+			console.log(value);
+			this.fire('change', { value: value });
+		}.bind(this), 500);
 	}
 });


### PR DESCRIPTION
`on-input` event occurs immediately after modification, unlike the `on-change` event, which occurs when the element loses focus

