### PR TITLE
DE36742 -- Fixed rubric descriptions not updating correctly when deleting or pasting text

### DIFF
--- a/editor/d2l-rubric-text-editor.js
+++ b/editor/d2l-rubric-text-editor.js
@@ -96,6 +96,9 @@ Polymer({
 		var value = this._getTextValue(e);
 		if (this.richTextEnabled) {
 			this.value = value;
+			/* In the HTML Editor case, this function is called when the change
+			   event fires, which occurs only when pasting text or unfocusing
+			   the cell, so there is no reason to use debounce here. */
 			this.fire('text-changed', { value: value });
 		} else {
 			this.inputChanging = true;

--- a/editor/d2l-rubric-text-editor.js
+++ b/editor/d2l-rubric-text-editor.js
@@ -24,7 +24,7 @@ Polymer({
 			<d2l-input-textarea id="textEditor" hidden$="[[richTextEnabled]]" aria-invalid="[[ariaInvalid]]" aria-label$="[[ariaLabel]]" disabled="[[disabled]]" value="{{value}}" on-blur="_onInputBlur" on-input="_duringInputChange"></d2l-input-textarea>
 		</template>
 		<template is="dom-if" if="[[richTextEnabled]]">
-			<d2l-rubric-html-editor id="htmlEditor" token="[[token]]" hidden$="[[!richTextEnabled]]" aria-label$="[[ariaLabel]]" invalid="[[_stringIsTrue(ariaInvalid)]]" placeholder="[[placeholder]]" value="[[value]]" key="[[key]]" min-rows="[[minRows]]" max-rows="[[maxRows]]" on-blur="_onInputBlur" on-input="_duringInputChange"></d2l-rubric-html-editor>
+			<d2l-rubric-html-editor id="htmlEditor" token="[[token]]" hidden$="[[!richTextEnabled]]" aria-label$="[[ariaLabel]]" invalid="[[_stringIsTrue(ariaInvalid)]]" placeholder="[[placeholder]]" value="[[value]]" key="[[key]]" min-rows="[[minRows]]" max-rows="[[maxRows]]" on-change="_duringInputChange"></d2l-rubric-html-editor>
 		</template>
 `,
 
@@ -92,26 +92,24 @@ Polymer({
 	},
 
 	_duringInputChange: function(e) {
-		this.inputChanging = true;
 		e.stopPropagation();
 		var value = this._getTextValue(e);
 		if (this.richTextEnabled) {
 			this.value = value;
+			this.fire('text-changed', { value: value });
+		} else {
+			this.inputChanging = true;
+			this.debounce('input', function() {
+				if (this.inputChanging) {
+					this.inputChanging = false;
+					this.fire('text-changed', { value: value });
+				}
+			}.bind(this), 500);
 		}
-		this.debounce('input', function() {
-			if (this.inputChanging) {
-				this.inputChanging = false;
-				this.fire('text-changed', { value: value });
-			}
-		}.bind(this), 500);
 	},
 
 	_getTextValue: function(e) {
-		if (this.richTextEnabled) {
-			return e.target._getContent() ? e.target._getContent() : '';
-		} else {
-			return (e.detail && e.detail.hasOwnProperty('content')) ?
-				e.detail.content : e.target.value || '';
-		}
+		return (e.detail && e.detail.hasOwnProperty('content')) ?
+			e.detail.content : e.target.value || '';
 	}
 });


### PR DESCRIPTION
Switched `input` event, which doesn't catch lots of edge cases like pasting text to use `change` instead. This also only fires when unfocusing the cell which is nice since it saves making lots of unnecessary API calls. To ensure that there is no race condition when clicking the Done button while a cell is still focused, I made [this change](https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/5382/overview) in the LMS to make it wait for the request to complete before navigating away.