### PR TITLE
Add wrap for long outcomes names

### DIFF
--- a/d2l-rubric-alignments-indicator.js
+++ b/d2l-rubric-alignments-indicator.js
@@ -68,6 +68,7 @@ class RubricAlignmentsIndicator extends mixinBehaviors([
 		margin-bottom: 6px;
 		max-width: 360px;
 		line-height: 1.3em;
+		white-space: pre-wrap;
 	}
 
 	[hidden] {


### PR DESCRIPTION
Some outcomes don't have a short notation. The text of these outcomes extends beyond the edges of the tooltip. We'd like to wrap the text so that it is all visible.