### PR TITLE
Vwong/us111084 Disable editing options when it is a shared rubric

### DIFF
--- a/build/lang/en.js
+++ b/build/lang/en.js
@@ -136,6 +136,9 @@ D2L.PolymerBehaviors.Rubric.LocalizeBehavior.LangEnBehavior = {
 		'descriptionReadOnlyMode': 'Description (not visible to students)',
 		'descriptionReadOnlyPlaceholder': 'No description',
 		'groupNameSaveFailed': 'Saving criteria group name failed',
-		'makeRubricAvailableHeader': 'Make rubric available to'
+		'makeRubricAvailableHeader': 'Make rubric available to',
+		'rubricStatusPublished': 'Status: Published',
+		'rubricStatusArchived': 'Status: Archived',
+		'rubricStatusDraft': 'Status: Draft'
 	}
 };

--- a/editor/d2l-rubric-editor.js
+++ b/editor/d2l-rubric-editor.js
@@ -217,6 +217,9 @@ const $_documentContainer = html `
 			#associations-options {
 				margin-top: 0.05rem;
 			}
+			d2l-organization-availability-set {
+				padding-top: 0.5rem;
+			}
 		</style>
 		<d2l-rubric-editor-header id="rubric-header">
 			<div slot="title">[[localize('editRubric')]]</div>
@@ -236,6 +239,7 @@ const $_documentContainer = html `
 					<d2l-menu id="status-menu" label="Status"></d2l-menu>
 				</d2l-dropdown-menu>
 			</d2l-dropdown-button-subtle>
+			<span slot="header-end-content" hidden$="[[_canChangeStatus]]">[[_rubricStatusText]]</span>
 		</d2l-rubric-editor-header>
 		<template is="dom-if" if="[[_isLocked]]">
 			<d2l-alert id ="locked-alert" type="default" >
@@ -249,7 +253,7 @@ const $_documentContainer = html `
 			</d2l-alert>
 		</template>
 		<div id="rubric-name-container">
-			<template is="dom-if" if="[[!_isLocked]]">
+			<template is="dom-if" if="[[!_isReadOnly]]">
 				<label for="rubric-name">[[localize('name')]]*</label>
 				<d2l-rubric-autosaving-input
 					id="rubric-name"
@@ -267,21 +271,21 @@ const $_documentContainer = html `
 					</d2l-tooltip>
 				</template>
 			</template>
-			<template is="dom-if" if="[[_isLocked]]">
+			<template is="dom-if" if="[[_isReadOnly]]">
 				<h4>[[_rubricName]]</h4>
 			</template>
 		</div>
-		<template is="dom-if" if="[[!_isLocked]]">
+		<template is="dom-if" if="[[!_isReadOnly]]">
 			<d2l-rubric-structure-editor is-single-page-rubric="[[isSinglePageRubric]]" rich-text-enabled="[[richTextEnabled]]" percentage-format-alternate="[[percentageFormatAlternate]]" href="[[href]]" token="[[token]]" outcomes-title="[[outcomesTitle]]" browse-outcomes-text="[[browseOutcomesText]]" outcomes-tool-integration-enabled="[[outcomesToolIntegrationEnabled]]">
 			</d2l-rubric-structure-editor>
 		</template>
-		<template is="dom-if" if="[[_isLocked]]">
+		<template is="dom-if" if="[[_isReadOnly]]">
 			<d2l-rubric token="[[token]]" href="[[href]]" overall-score-flag="" read-only="">
 			</d2l-rubric>
 		</template>
 
 		<div id="accordion-container">
-			<d2l-accordion-collapse title="[[localize('options')]]" flex="" opened$="[[_isLocked]]">
+			<d2l-accordion-collapse title="[[localize('options')]]" flex="" opened$="[[_isReadOnly]]">
 				<div id="options-container">
 					<div id="visibility-container">
 						<d2l-rubric-visibility-editor href="[[href]]" token="[[token]]"></d2l-rubric-visibility-editor>
@@ -298,7 +302,7 @@ const $_documentContainer = html `
 						</template>
 					</div>
 					<div id="rubric-description-container">
-						<template is="dom-if" if="[[!_isLocked]]">
+						<template is="dom-if" if="[[!_isReadOnly]]">
 							<label for="rubric-description">[[localize('description')]]</label>
 							<div class="d2l-body-compact">[[localize('descriptionInfo')]]</div>
 							<d2l-rubric-text-editor id="rubric-description" key="[[_getSelfLink(entity)]]" token="[[token]]" aria-invalid="[[isAriaInvalid(_descriptionInvalid)]]" aria-label$="[[localize('description')]]" disabled="[[!_canEditDescription]]" value="{{_rubricDescription}}" input-changing="{{_descriptionChanging}}" pending-saves="[[_pendingDescriptionSaves]]" on-text-changed="_saveDescription" rich-text-enabled="[[_richTextAndEditEnabled(richTextEnabled,_canEditDescription)]]">
@@ -309,7 +313,7 @@ const $_documentContainer = html `
 								</d2l-tooltip>
 							</template>
 						</template>
-						<template is="dom-if" if="[[_isLocked]]">
+						<template is="dom-if" if="[[_isReadOnly]]">
 							<label for="rubric-description">[[localize('descriptionReadOnlyMode')]]</label>
 							<template is="dom-if" if="[[richTextEnabled]]">
 								<div id="description-html-container">
@@ -535,6 +539,10 @@ Polymer({
 		},
 		_isLocked: {
 			type: Boolean,
+			value: false
+		},
+		_isReadOnly: {
+			type: Boolean,
 			value: false,
 			observer: '_loadRubricPreviewComponents'
 		},
@@ -728,8 +736,17 @@ Polymer({
 					}
 				}
 				this._canChangeStatus = true;
+			} else {
+				if (entity.hasClass('published')) {
+					this._rubricStatusText = this.localize('rubricStatusPublished');
+				} else if (entity.hasClass('archived')) {
+					this._rubricStatusText = this.localize('rubricStatusArchived');
+				} else if (entity.hasClass('draft')) {
+					this._rubricStatusText = this.localize('rubricStatusDraft');
+				}
 			}
 			this._isLocked = entity.hasClass('locked');
+			this._isReadOnly = entity.hasClass('locked') || entity.hasClass('shared');
 			this._isHolistic = entity.hasClass(this.HypermediaClasses.rubrics.holistic);
 
 			var nameChanged = oldEntity ? this._getRubricName(entity) !== this._getRubricName(oldEntity) : true;
@@ -919,8 +936,8 @@ Polymer({
 			this._helpAssociations.properties.descriptionLangTerm
 		);
 	},
-	_loadRubricPreviewComponents: function(isLocked) {
-		if (isLocked) {
+	_loadRubricPreviewComponents: function(isReadOnly) {
+		if (isReadOnly) {
 			import('../d2l-rubric.js');
 		}
 	}

--- a/editor/d2l-rubric-visibility-editor.js
+++ b/editor/d2l-rubric-visibility-editor.js
@@ -41,17 +41,41 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-visibility-editor">
 				display: block;
 				margin-bottom: 0.7rem;
 			}
+			#static-visibility-text {
+				padding-top: 0.5rem;
+			}
 		</style>
 		<label class="heading">[[localize('rubricVisibility')]]</label>
-		<label class="d2l-input-radio-label">
-			<input type="radio" id="AlwaysVisible" on-focus="_handleFocus" on-blur="_handleBlur" value="AlwaysVisible" name="visibility" on-change="_changeVisibility">[[localize('rubricVisibilityAlways')]]
-		</label>
-		<label class="d2l-input-radio-label">
-			<input type="radio" id="NeverVisible" on-focus="_handleFocus" on-blur="_handleBlur" value="NeverVisible" name="visibility" on-change="_changeVisibility">[[localize('rubricVisibilityNever')]]
-		</label>
-		<label class="d2l-input-radio-label">
-			<input type="radio" id="VisibleOnceFeedbackPosted" on-focus="_handleFocus" on-blur="_handleBlur" value="VisibleOnceFeedbackPosted" name="visibility" on-change="_changeVisibility">[[localize('rubricVisibilityOnceFeedbackPosted')]]
-		</label>
+		<div id="static-visibility-text" hidden$="[[canEdit]]">[[_staticVisibilityText]]</div>
+		<div hidden$="[[!_canEdit]]">
+			<label class="d2l-input-radio-label">
+				<input type="radio"
+					id="AlwaysVisible"
+					on-focus="_handleFocus"
+					on-blur="_handleBlur"
+					value="AlwaysVisible"
+					name="visibility"
+					on-change="_changeVisibility">[[localize('rubricVisibilityAlways')]]
+			</label>
+			<label class="d2l-input-radio-label">
+				<input type="radio"
+					id="NeverVisible"
+					on-focus="_handleFocus"
+					on-blur="_handleBlur"
+					value="NeverVisible"
+					name="visibility"
+					on-change="_changeVisibility">[[localize('rubricVisibilityNever')]]
+			</label>
+			<label class="d2l-input-radio-label">
+				<input type="radio"
+					id="VisibleOnceFeedbackPosted"
+					on-focus="_handleFocus"
+					on-blur="_handleBlur"
+					value="VisibleOnceFeedbackPosted"
+					name="visibility"
+					on-change="_changeVisibility">[[localize('rubricVisibilityOnceFeedbackPosted')]]
+			</label>
+		</div>
 		<template is="dom-if" if="[[_visibilityInvalid]]">
 			<d2l-tooltip id="visibility-bubble" class="is-error" position="bottom">[[_visibilityInvalidError]]</d2l-tooltip>
 		</template>
@@ -91,6 +115,13 @@ Polymer({
 			type: String,
 			value: null
 		},
+		_canEdit: {
+			type: Boolean,
+			computed: '_computeCanEdit(entity)',
+		},
+		_staticVisibilityText: {
+			type: String
+		},
 	},
 	behaviors: [
 		D2L.PolymerBehaviors.Rubric.EntityBehavior,
@@ -111,6 +142,21 @@ Polymer({
 					if (field.value[i].selected) {
 						dom(this.root).querySelector('#' + field.value[i].value).checked = true;
 					}
+				}
+			}
+		} else {
+			const visibilitySelected = entity && entity.properties && entity.properties.visibility;
+			if (visibilitySelected) {
+				switch (visibilitySelected) {
+					case 'AlwaysVisible':
+						this._staticVisibilityText = this.localize('rubricVisibilityAlways');
+						break;
+					case 'VisibleOnceFeedbackPosted':
+						this._staticVisibilityText = this.localize('rubricVisibilityOnceFeedbackPosted');
+						break;
+					case 'NeverVisible':
+						this._staticVisibilityText = this.localize('rubricVisibilityNever');
+						break;
 				}
 			}
 		}
@@ -152,5 +198,8 @@ Polymer({
 				{bubbles: true, composed: true}
 			));
 		}
+	},
+	_computeCanEdit: function(entity) {
+		return entity && entity.hasActionByName('update-visibility');
 	}
 });

--- a/lang/en.json
+++ b/lang/en.json
@@ -125,5 +125,8 @@
 	"descriptionReadOnlyMode": "Description (not visible to students)",
 	"descriptionReadOnlyPlaceholder": "No description",
 	"groupNameSaveFailed": "Saving criteria group name failed",
-	"makeRubricAvailableHeader": "Make rubric available to"
+	"makeRubricAvailableHeader": "Make rubric available to",
+	"rubricStatusPublished": "Status: Published",
+	"rubricStatusArchived": "Status: Archived",
+	"rubricStatusDraft": "Status: Draft"
 }


### PR DESCRIPTION
- Show read-only rubric editor for shared rubrics
- Display rubric status as static text instead of a dropdown. This is because the dropdown choices come from the action, which is not included for shared rubrics. We determine what to display but relying on the class included in the entity (`published`, `archived`, or `draft`). Then we have to localize it in `d2l-rubric`.
- Display rubric visibility as static text instead of radio buttons. This is because the radio button choices come from the action, which is not included for shared rubrics. The choice selected is obtained from the entity's properties and localized in `d2l-rubric`.