### PR TITLE
Fix incorrect accesses of input Shadow DOM

### DIFF
--- a/d2l-rubric-editable-score.js
+++ b/d2l-rubric-editable-score.js
@@ -250,9 +250,9 @@ Polymer({
 	focus: function() {
 		var elem = this.$['text-area'];
 		elem.focus();
-		var inputElem = elem.$$('input');
+		var inputElem = elem.shadowRoot.querySelector('input');
 		if (inputElem && this._largeScreen) {
-			elem.$$('input').select();
+			inputElem.select();
 		}
 	},
 

--- a/d2l-rubric-editable-score.js
+++ b/d2l-rubric-editable-score.js
@@ -66,17 +66,17 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-editable-score">
 			}
 			.clear-override-button-mobile {
 				display: none;
-			} 
+			}
 			.override-label {
 				display: none;
-			} 
+			}
 			@media screen and (max-width: 614px) {
 				.clear-override-button-mobile {
 					display: inline-flex;
 					padding: 6px 0;
 				}
 				.override-label {
-					margin-left: 12px;	
+					margin-left: 12px;
 					padding: 6px 0;
 					display: inline-flex;
 					font-size: 15px;
@@ -109,7 +109,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-editable-score">
 					<d2l-input-text id="text-area" value="{{_score}}" type="number" step="any" min="0" max="100000" on-change="_changeHandler" on-input="_inputHandler" on-blur="_blurHandler" on-keypress="_handleKey" aria-invalid="[[isAriaInvalid(scoreInvalid)]]" prevent-submit="">
 					</d2l-input-text>
 					<div id="out-of" class="right">[[_localizeOutOf(entity)]]</div>
-				</div>	
+				</div>
 				<template is="dom-if" if="[[scoreInvalid]]">
 					<d2l-tooltip id="score-bubble" for="text-area" class="is-error" position="bottom">[[scoreInvalidError]]</d2l-tooltip>
 				</template>
@@ -288,7 +288,8 @@ Polymer({
 		if (event.relatedTarget && event.relatedTarget.id === 'clear-button') {
 			return;
 		}
-		var innerInput = event.target.$$('input');
+		var innerInput = event.target.shadowRoot.querySelector('input');
+
 		if (!innerInput || !innerInput.checkValidity()) {
 			return;
 		}

--- a/editor/d2l-rubric-criteria-groups-editor.js
+++ b/editor/d2l-rubric-criteria-groups-editor.js
@@ -183,7 +183,7 @@ Polymer({
 	_refocus: function() {
 		var allGroups = dom(this.root).querySelectorAll('d2l-rubric-criteria-group-editor');
 		var lastGroup = allGroups[allGroups.length - 1];
-		lastGroup.$$('d2l-input-text').$$('input').select();
+		lastGroup.$$('d2l-input-text').shadowRoot.querySelector('input').select();
 	},
 	_totalScoreChanged: function(totalScore) {
 		this._hasTotalScore = typeof totalScore !== 'undefined';

--- a/editor/d2l-rubric-criteria-groups-editor.js
+++ b/editor/d2l-rubric-criteria-groups-editor.js
@@ -8,6 +8,7 @@ import './d2l-rubric-criteria-group-editor.js';
 import 'd2l-button/d2l-button.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status';
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criteria-groups-editor">
@@ -182,8 +183,18 @@ Polymer({
 	},
 	_refocus: function() {
 		var allGroups = dom(this.root).querySelectorAll('d2l-rubric-criteria-group-editor');
+
+		if (!allGroups.length) {
+			return;
+		}
+
 		var lastGroup = allGroups[allGroups.length - 1];
-		lastGroup.$$('d2l-input-text').shadowRoot.querySelector('input').select();
+
+		afterNextRender(this, () => {
+			lastGroup
+				.shadowRoot.querySelector('d2l-input-text')
+				.shadowRoot.querySelector('input').select();
+		});
 	},
 	_totalScoreChanged: function(totalScore) {
 		this._hasTotalScore = typeof totalScore !== 'undefined';


### PR DESCRIPTION
Some functions are currently expecting Polymer convenience methods to exist on external web components in order to access their Shadow DOM, which have since been upgraded to LitElement. For now, access it through the spec-compliant method - probably in the future these should expose a more standard interface themselves.

Currently causes autosave for editable scores to fail, as well as a few other UX issues.