### PR TITLE
Fix out of order points error issue

### DIFF
--- a/editor/d2l-rubric-level-editor.js
+++ b/editor/d2l-rubric-level-editor.js
@@ -307,8 +307,7 @@ Polymer({
 					this._updatePoints(this.entity, false);
 
 					const savePointsEvent = new CustomEvent('save-points');
-					savePointsEvent.points = saveEvent.value;
-					savePointsEvent.name = this._levelName;
+					savePointsEvent.id = this.entity.properties.id;
 					this.dispatchEvent(savePointsEvent);
 				}.bind(this)).catch(function(err) {
 					if (this._usesPercentage) {

--- a/editor/d2l-rubric-levels-editor.js
+++ b/editor/d2l-rubric-levels-editor.js
@@ -248,11 +248,13 @@ Polymer({
 		this.fire('iron-announce', { text: this.localize('addLevelAppend', 'name', this._getLastLevelName()) }, { bubbles: true });
 	},
 	_onSavePoints: function(event) {
-		// Upon successful save, we attempt to save other levels that have previously had errors saving (ex. out of bounds errors)
+		// Upon successful save, we attempt to save other levels that have previously had errors saving
 		var levels = Array.from(dom(this.root).querySelectorAll('d2l-rubric-level-editor'));
 		var saveIndex = levels.findIndex((level) => {
 			return level.entity.properties.id === event.id;
 		});
+
+		// To prevent false out of bounds errors, we call savePointsAfterError in an order starting from the levels adjacent to the saved level
 		for (let i = saveIndex + 1; i < levels.length; i++) {
 			levels[i].savePointsAfterError();
 		}

--- a/editor/d2l-rubric-levels-editor.js
+++ b/editor/d2l-rubric-levels-editor.js
@@ -241,7 +241,7 @@ Polymer({
 		// Upon successful save, we attempt to save other levels that have previously had errors saving (ex. out of bounds errors)
 		var levels = Array.from(dom(this.root).querySelectorAll('d2l-rubric-level-editor'));
 		var saveIndex = levels.findIndex((level) => {
-			level.entity.properties.name === event.name;
+			return level.entity.properties.id === event.id;
 		});
 		for (let i = saveIndex + 1; i < levels.length; i++) {
 			levels[i].savePointsAfterError();

--- a/editor/d2l-rubric-levels-editor.js
+++ b/editor/d2l-rubric-levels-editor.js
@@ -113,7 +113,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-levels-editor">
 		<div id="levels-section" style="display: inherit; flex: 1 1 auto;">
 			<template is="dom-repeat" items="[[_levels]]" as="level">
 				<div class="cell" is-holistic$="[[isHolistic]]">
-					<d2l-rubric-level-editor href="[[_getSelfLink(level)]]" token="[[token]]" has-out-of="[[hasOutOf]]" percentage-format-alternate="[[percentageFormatAlternate]]" updating-levels="{{updatingLevels}}">
+					<d2l-rubric-level-editor href="[[_getSelfLink(level)]]" token="[[token]]" has-out-of="[[hasOutOf]]" percentage-format-alternate="[[percentageFormatAlternate]]" updating-levels="{{updatingLevels}}" on-save-points="_onSavePoints">
 					</d2l-rubric-level-editor>
 				</div>
 			</template>
@@ -132,6 +132,7 @@ Polymer({
 
 	properties: {
 		_levels: Array,
+		_levelPointsError: Array,
 		hasOutOf: {
 			type: Boolean,
 			value: false
@@ -235,5 +236,18 @@ Polymer({
 	},
 	_onAppendFocus: function() {
 		this.fire('iron-announce', { text: this.localize('addLevelAppend', 'name', this._getLastLevelName()) }, { bubbles: true });
+	},
+	_onSavePoints: function(event) {
+		// Upon successful save, we attempt to save other levels that have previously had errors saving (ex. out of bounds errors)
+		var levels = Array.from(dom(this.root).querySelectorAll('d2l-rubric-level-editor'));
+		var saveIndex = levels.findIndex((level) => {
+			level.entity.properties.name === event.name;
+		});
+		for (let i = saveIndex + 1; i < levels.length; i++) {
+			levels[i].savePointsAfterError();
+		}
+		for (let i = saveIndex - 1; i >= 0; i--) {
+			levels[i].savePointsAfterError();
+		}
 	}
 });

--- a/editor/d2l-rubric-levels-editor.js
+++ b/editor/d2l-rubric-levels-editor.js
@@ -132,7 +132,6 @@ Polymer({
 
 	properties: {
 		_levels: Array,
-		_levelPointsError: Array,
 		hasOutOf: {
 			type: Boolean,
 			value: false

--- a/editor/d2l-rubric-overall-level-editor.js
+++ b/editor/d2l-rubric-overall-level-editor.js
@@ -142,6 +142,9 @@ Polymer({
 		_rangeStart: {
 			type: Number
 		},
+		_unsavedRangeStart: {
+			type: String
+		},
 		_hasRangeStart: {
 			type: Boolean,
 			computed: '_hasRangeStartValue(entity)'
@@ -253,13 +256,30 @@ Polymer({
 			} else {
 				this.toggleBubble('_rangeStartInvalid', false, 'range-start-bubble');
 				var fields = [{'name':'rangeStart', 'value': saveEvent.value}];
+				this._unsavedRangeStart = saveEvent.value;
 				this.performAutosaveAction(action, fields, '_pendingRangeStartSaves').then(function() {
 					this.fire('d2l-rubric-overall-level-range-start-saved');
 					this._updateRangeStart(this.entity, false);
+
+					const saveRangeStartEvent = new CustomEvent('save-range-start');
+					saveRangeStartEvent.id = this.entity.properties.id;
+					this.dispatchEvent(saveRangeStartEvent);
 				}.bind(this)).catch(function(err) {
 					this.handleValidationError('range-start-bubble', '_rangeStartInvalid', 'rangeStartInvalid', err);
 				}.bind(this));
 			}
+		}
+	},
+	saveRangeStartAfterError: function() {
+		var action = this.entity.getActionByName('update-range-start');
+		if (action && this._rangeStartInvalid) {
+			var fields = [{'name':'rangeStart', 'value': this._unsavedRangeStart}];
+			this.performAutosaveAction(action, fields, '_pendingRangeStartSaves').then(function() {
+				this.fire('d2l-rubric-overall-level-range-start-saved');
+				this._updateRangeStart(this.entity, false);
+			}.bind(this)).catch(function(err) {
+				this.handleValidationError('range-start-bubble', '_rangeStartInvalid', 'rangeStartInvalid', err);
+			}.bind(this));
 		}
 	},
 	_updateRangeStart: function(entity, selfLinkChanged) {

--- a/editor/d2l-rubric-overall-level-editor.js
+++ b/editor/d2l-rubric-overall-level-editor.js
@@ -261,9 +261,12 @@ Polymer({
 					this.fire('d2l-rubric-overall-level-range-start-saved');
 					this._updateRangeStart(this.entity, false);
 
-					const saveRangeStartEvent = new CustomEvent('save-range-start');
-					saveRangeStartEvent.id = this.entity.properties.id;
-					this.dispatchEvent(saveRangeStartEvent);
+					var link = this.entity.getLinkByRel('self');
+					if (link) {
+						const saveRangeStartEvent = new CustomEvent('save-range-start');
+						saveRangeStartEvent.href = link.href;
+						this.dispatchEvent(saveRangeStartEvent);
+					}
 				}.bind(this)).catch(function(err) {
 					this.handleValidationError('range-start-bubble', '_rangeStartInvalid', 'rangeStartInvalid', err);
 				}.bind(this));

--- a/editor/d2l-rubric-overall-levels-editor.js
+++ b/editor/d2l-rubric-overall-levels-editor.js
@@ -318,15 +318,16 @@ Polymer({
 		// Upon successful save, we attempt to save other levels that have previously had errors saving
 		var levels = Array.from(dom(this.root).querySelectorAll('d2l-rubric-overall-level-editor'));
 		var saveIndex = levels.findIndex((level) => {
-			return level.entity.properties.id === event.id;
+			var link = level.entity.getLinkByRel('self');
+			return link ? link.href === event.href : false;
 		});
 
 		// To prevent false out of bounds errors, we call savePointsAfterError in an order starting from the levels adjacent to the saved level
 		for (let i = saveIndex + 1; i < levels.length; i++) {
-			levels[i].savePointsAfterError();
+			levels[i].saveRangeStartAfterError();
 		}
 		for (let i = saveIndex - 1; i >= 0; i--) {
-			levels[i].savePointsAfterError();
+			levels[i].saveRangeStartAfterError();
 		}
 	}
 });

--- a/editor/d2l-rubric-overall-levels-editor.js
+++ b/editor/d2l-rubric-overall-levels-editor.js
@@ -171,7 +171,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-overall-leve
 				<div class="col-center" id="level-header-center-section">
 					<template is="dom-repeat" items="[[_overallLevels]]" as="overallLevel">
 						<div class="cell">
-							<d2l-rubric-overall-level-editor href="[[_getSelfLink(overallLevel)]]" token="[[token]]"></d2l-rubric-overall-level-editor>
+							<d2l-rubric-overall-level-editor href="[[_getSelfLink(overallLevel)]]" token="[[token]]" on-save-range-start="_onSaveRangeStart"></d2l-rubric-overall-level-editor>
 						</div>
 					</template>
 				</div>
@@ -313,5 +313,20 @@ Polymer({
 	},
 	_isLastAndCorner: function(index, levelCount) {
 		return index === levelCount - 1;
+	},
+	_onSaveRangeStart: function(event) {
+		// Upon successful save, we attempt to save other levels that have previously had errors saving
+		var levels = Array.from(dom(this.root).querySelectorAll('d2l-rubric-overall-level-editor'));
+		var saveIndex = levels.findIndex((level) => {
+			return level.entity.properties.id === event.id;
+		});
+
+		// To prevent false out of bounds errors, we call savePointsAfterError in an order starting from the levels adjacent to the saved level
+		for (let i = saveIndex + 1; i < levels.length; i++) {
+			levels[i].savePointsAfterError();
+		}
+		for (let i = saveIndex - 1; i >= 0; i--) {
+			levels[i].savePointsAfterError();
+		}
 	}
 });


### PR DESCRIPTION
[DE34471](https://rally1.rallydev.com/#/detail/defect/309752498680?fdp=true): Out of order points error message does not go away if you correct the point order by editing a cell that does not have the error associated with it

Levels can only be changed one at a time through the API. When there is an out-of-order points error, the offending level does not get saved. If the error is corrected by editing a level that is not the offending level, the error message remains and the offending level still does not get saved. We can fix this by attempting to save levels with errors whenever there is a successful save by another level.