### PR TITLE
DE37276

### DIFF
--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -757,7 +757,7 @@ Polymer({
 		deleteButton.setAttribute('disabled', '');
 		this.openConfirm({
 			title: this.localize('deleteCriterionConfirmationTitle'),
-			secondaryMessage: this.localize('deleteCriterionConfirmationText'),
+			secondaryMessage: action.title || this.localize('deleteCriterionConfirmationText'),
 			positiveButtonText: this.localize('deleteConfirmationYes'),
 			negativeButtonText: this.localize('deleteConfirmationNo')
 		}).then(function() {

--- a/editor/d2l-rubric-level-editor.js
+++ b/editor/d2l-rubric-level-editor.js
@@ -352,7 +352,7 @@ Polymer({
 		deleteButton.setAttribute('disabled', '');
 		this.openConfirm({
 			title: this.localize('deleteLevelConfirmationTitle'),
-			secondaryMessage: this.localize('deleteLevelConfirmationText'),
+			secondaryMessage: action.title || this.localize('deleteLevelConfirmationText'),
 			positiveButtonText: this.localize('deleteConfirmationYes'),
 			negativeButtonText: this.localize('deleteConfirmationNo')
 		}).then(function() {

--- a/editor/d2l-rubric-overall-level-editor.js
+++ b/editor/d2l-rubric-overall-level-editor.js
@@ -302,7 +302,7 @@ Polymer({
 
 		this.openConfirm({
 			title: this.localize('deleteLevelConfirmationTitle'),
-			secondaryMessage: this.localize('deleteLevelConfirmationText'),
+			secondaryMessage: action.title || this.localize('deleteLevelConfirmationText'),
 			positiveButtonText: this.localize('deleteConfirmationYes'),
 			negativeButtonText: this.localize('deleteConfirmationNo')
 		}).then(function() {


### PR DESCRIPTION
If the LMS provided an override for the delete confirmation message, use that instead of the default message

Required for the changes in https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/7793/overview to be reflected in the new rubrics create experience

BSI build with this change for testing: https://s.brightspace.com/lib/bsi/dev/95ed17e4f56197f6c752b92f270bb9ce0716eed9/