### PR TITLE
Load the telemetry endpoint from the html root element

### DIFF
--- a/d2l-rubric.js
+++ b/d2l-rubric.js
@@ -392,7 +392,7 @@ Polymer({
 			this._telemetryData = {
 				rubricMode: this.dataset.rubricMode,
 				originTool: this.dataset.originTool,
-				endpoint: this.dataset.telemetryEndpoint,
+				endpoint: window.document.documentElement.dataset.telemetryEndpoint,
 				performanceTelemetryEnabled: this.performanceTelemetryFlag
 			};
 

--- a/d2l-rubric.js
+++ b/d2l-rubric.js
@@ -354,6 +354,11 @@ Polymer({
 			type: String,
 			value: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPg0KICA8ZGVmcz4NCiAgICA8cGF0aCBpZD0iYSIgZD0iTTAgMGgyNHYyNEgweiIvPg0KICA8L2RlZnM+DQogIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xIC0xKSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4NCiAgICA8bWFzayBpZD0iYiIgZmlsbD0iI2ZmZiI+DQogICAgICA8dXNlIHhsaW5rOmhyZWY9IiNhIi8+DQogICAgPC9tYXNrPg0KICAgIDxwYXRoIGQ9Ik02IDIyLjY2N0E0LjY2NyA0LjY2NyAwIDAgMCAxMC42NjcgMThjMC0xLjIyNy0uNTU5LTIuNS0xLjMzNC0zLjMzM0M4LjQ4MSAxMy43NSA3LjM1IDEzLjMzMyA2IDEzLjMzM2MtLjQxMSAwIDEuMzMzLTYuNjY2IDMtOSAxLjY2Ny0yLjMzMyAxLjMzMy0zIC4zMzMtM0M4IDEuMzMzIDUuMjUzIDQuNTg2IDQgNy4yNTUgMS43NzMgMTIgMS4zMzMgMTUuMzkyIDEuMzMzIDE4QTQuNjY3IDQuNjY3IDAgMCAwIDYgMjIuNjY3ek0xOCAyMi42NjdBNC42NjcgNC42NjcgMCAwIDAgMjIuNjY3IDE4YzAtMS4yMjctLjU1OS0yLjUtMS4zMzQtMy4zMzMtLjg1Mi0uOTE3LTEuOTgzLTEuMzM0LTMuMzMzLTEuMzM0LS40MTEgMCAxLjMzMy02LjY2NiAzLTkgMS42NjctMi4zMzMgMS4zMzMtMyAuMzMzLTMtMS4zMzMgMC00LjA4IDMuMjUzLTUuMzMzIDUuOTIyQzEzLjc3MyAxMiAxMy4zMzMgMTUuMzkyIDEzLjMzMyAxOEE0LjY2NyA0LjY2NyAwIDAgMCAxOCAyMi42Njd6IiBmaWxsPSIjRDNEOUUzIiBtYXNrPSJ1cmwoI2IpIi8+DQogIDwvZz4NCjwvc3ZnPg=='
 		},
+		telemetryFlag: {
+			type: Boolean,
+			value: false,
+			reflectToAttribute: true,
+		},
 		performanceTelemetryFlag: {
 			type: Boolean,
 			value: false,
@@ -389,10 +394,15 @@ Polymer({
 
 	_onEntityChanged: function(entity) {
 		if (entity) {
+			var telemetryEndpoint = null;
+			if (this.telemetryFlag) {
+				telemetryEndpoint = window.document.documentElement.dataset.telemetryEndpoint;
+			}
+
 			this._telemetryData = {
 				rubricMode: this.dataset.rubricMode,
 				originTool: this.dataset.originTool,
-				endpoint: window.document.documentElement.dataset.telemetryEndpoint,
+				endpoint: telemetryEndpoint,
 				performanceTelemetryEnabled: this.performanceTelemetryFlag
 			};
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-telemetry-endpoint="https://qa.telemetryservice.brightspace.com/api/events">
 
 <head>
 	<meta charset="utf-8">
@@ -80,7 +80,7 @@
 			token="foozleberries"
 			data-origin-tool="grades"
 			data-rubric-mode="graded"
-			data-telemetry-endpoint="https://qa.telemetryservice.brightspace.com/api/events"
+			telemetry-flag=""
 			outcomes-title-text="Standards"
 		></d2l-rubric>
 	</demo-snippet>


### PR DESCRIPTION
The telemetry endpoint is already added to every page by putting it in the dataset of the root HTML element:

https://search.d2l.dev/xref/lms/lp/framework/web/D2L.LP.Web/UI/Telemetry/TelemetryEndpointHtmlElementAttributeProvider.cs

https://search.d2l.dev/xref/lms/lp/framework/web/D2L.Web/ui/page/d2lPageControl.cs#953

Changed the component to load from this instead of relying on the value being passed through to the component directly.