### PR TITLE
US112900 -- Add error logging to rubrics telemetry

### DIFF
--- a/assessment-behavior.js
+++ b/assessment-behavior.js
@@ -2,7 +2,7 @@ import AssessmentHelper from './assessment-helpers/assessment.js';
 import CriterionAssessmentHelper from './assessment-helpers/criterion-assessment.js';
 import CriterionCellAssessmentHelper from './assessment-helpers/criterion-cell-assessment.js';
 import OverallLevelAssessmentHelper from './assessment-helpers/overall-level-assessment.js';
-import 'd2l-polymer-siren-behaviors/store/siren-action-behavior.js';
+import './d2l-rubric-action-behavior.js';
 
 window.D2L = window.D2L || {};
 
@@ -58,5 +58,5 @@ D2L.PolymerBehaviors.Rubric.AssessmentBehaviorImpl = {
 /** @polymerBehavior */
 D2L.PolymerBehaviors.Rubric.AssessmentBehavior = [
 	D2L.PolymerBehaviors.Rubric.AssessmentBehaviorImpl,
-	D2L.PolymerBehaviors.Siren.SirenActionBehavior
+	D2L.PolymerBehaviors.Rubric.ActionBehavior
 ];

--- a/d2l-rubric-action-behavior.js
+++ b/d2l-rubric-action-behavior.js
@@ -1,0 +1,33 @@
+import 'd2l-polymer-siren-behaviors/store/siren-action-behavior.js';
+
+window.D2L = window.D2L || {};
+window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
+window.D2L.PolymerBehaviors.Rubric = window.D2L.PolymerBehaviors.Rubric || {};
+
+/*
+* Behavior for performing siren actions and logging API errors
+* @polymerBehavior
+*/
+D2L.PolymerBehaviors.Rubric.ActionBehaviorImpl = {
+	performSirenAction: function(action, fields, immediate) {
+		const base = D2L.PolymerBehaviors.Siren.SirenActionBehaviorImpl;
+		return base.performSirenAction.call(this, action, fields, immediate).catch(err => {
+			this.dispatchEvent(new CustomEvent('d2l-rubric-action-error', {
+				detail: {
+					url: base.getEntityUrl.call(this, action, fields),
+					method: action.method,
+					error: err
+				},
+				composed: true,
+				bubbles: true,
+			}));
+			throw err;
+		});
+	}
+};
+
+/** @polymerBehavior */
+D2L.PolymerBehaviors.Rubric.ActionBehavior = [
+	D2L.PolymerBehaviors.Siren.SirenActionBehavior,
+	D2L.PolymerBehaviors.Rubric.ActionBehaviorImpl
+];

--- a/d2l-rubric-overall-score.js
+++ b/d2l-rubric-overall-score.js
@@ -9,7 +9,7 @@ import 's-html/s-html.js';
 import 'd2l-table/d2l-scroll-wrapper.js';
 import 'd2l-icons/tier1-icons.js';
 import 'd2l-offscreen/d2l-offscreen.js';
-import 'd2l-polymer-siren-behaviors/store/siren-action-behavior.js';
+import './d2l-rubric-action-behavior.js';
 import './assessment-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
@@ -253,7 +253,7 @@ Polymer({
 		D2L.PolymerBehaviors.Rubric.EntityBehavior,
 		window.D2L.Hypermedia.HMConstantsBehavior,
 		D2L.PolymerBehaviors.Rubric.LocalizeBehavior,
-		D2L.PolymerBehaviors.Siren.SirenActionBehavior,
+		D2L.PolymerBehaviors.Rubric.ActionBehavior,
 		D2L.PolymerBehaviors.Rubric.AssessmentBehavior
 	],
 

--- a/d2l-rubric.js
+++ b/d2l-rubric.js
@@ -384,7 +384,8 @@ Polymer({
 		'd2l-siren-entity-save-end': '_onEntitySave',
 		'd2l-siren-entity-error': '_handleError',
 		'd2l-alert-button-pressed': '_pageReload',
-		'd2l-rubric-compact-view-accordion': '_onAccordionCollapseExpand'
+		'd2l-rubric-compact-view-accordion': '_onAccordionCollapseExpand',
+		'd2l-rubric-action-error': '_onSirenActionError'
 	},
 
 	ready: function() {
@@ -522,6 +523,15 @@ Polymer({
 	},
 
 	_handleError: function(e) {
+		if (e && e['target']) {
+			this.logApiError(
+				e.target.href,
+				'GET',
+				(e.detail && typeof e.detail['error'] === 'number') ? e.detail.error : null,
+				this._telemetryData
+			);
+		}
+
 		if (this._errored) {
 			return;
 		}
@@ -592,6 +602,16 @@ Polymer({
 
 	_waitForCachePrimer: function(href, isPrimed) {
 		return isPrimed ? href : null;
+	},
+
+	_onSirenActionError: function(event) {
+		this.logApiError(
+			event.detail.url,
+			event.detail.method,
+			(typeof event.detail.error === 'number') ? event.detail.error : null,
+			this._telemetryData
+		);
+		event.stopPropagation();
 	},
 
 	_attachErrorHandler: function(telemetryData) {

--- a/telemetry-behavior.js
+++ b/telemetry-behavior.js
@@ -130,7 +130,7 @@ D2L.PolymerBehaviors.Rubric.TelemetryBehaviorImpl = {
 
 		window.performance.measure(viewName, startMark, endMark);
 
-		const eventBody = this._createEventBody(actionName, telemetryData)
+		const eventBody = this._createEventBody(actionName, telemetryData, null, true)
 			.addUserTiming(window.performance.getEntriesByName(viewName));
 		this._logEvent(eventBody, telemetryData, false);
 
@@ -144,7 +144,7 @@ D2L.PolymerBehaviors.Rubric.TelemetryBehaviorImpl = {
 		return window.performance.getEntriesByName(markName, 'mark').length > 0 ? true : false;
 	},
 
-	_createEventBody: function(action, telemetryData, customJson) {
+	_createEventBody: function(action, telemetryData, customJson, isPerformanceLog) {
 		const common = this._getCommonProperties();
 		if (!customJson) {
 			customJson = common;
@@ -154,7 +154,11 @@ D2L.PolymerBehaviors.Rubric.TelemetryBehaviorImpl = {
 			}
 		}
 
-		return new window.d2lTelemetryBrowserClient.EventBody()
+		const eventBody = isPerformanceLog ?
+			new window.d2lTelemetryBrowserClient.PerformanceEventBody() :
+			new window.d2lTelemetryBrowserClient.EventBody();
+
+		return eventBody
 			.setAction(action)
 			.setTenantUrl(location.hostname)
 			.addCustom('rubricMode', (telemetryData || {}).rubricMode || 'unknown')

--- a/telemetry-behavior.js
+++ b/telemetry-behavior.js
@@ -77,7 +77,7 @@ D2L.PolymerBehaviors.Rubric.TelemetryBehaviorImpl = {
 
 	logJavascriptError: function(message, error, telemetryData, source, line, column) {
 		const errorInfo = {
-			Name: (error instanceof Error) ? error.name : typeof error,
+			Name: (error && typeof error['name'] === 'string') ? error.name : typeof error,
 			Message: message || '',
 			Source: source || null,
 			Line: typeof line === 'number' ? line : null,


### PR DESCRIPTION
 * Add some additional properties to all telemetry events:
    * The page URL
    * The referrer URL
    * The LMS Version
    * The BSI Version
 * Log an event when a siren entity fails to be fetched or a siren action fails
 * Log an event when an unhandled javascript error happens on the page

Test BSI build with changes: https://s.brightspace.com/lib/bsi/dev/453abce202f9ce88c00bda18d3041b08601be026/