### PR TITLE
switching over the labs version of accordion

### DIFF
--- a/d2l-rubric-adapter.js
+++ b/d2l-rubric-adapter.js
@@ -1,7 +1,7 @@
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '@polymer/iron-media-query/iron-media-query.js';
-import 'd2l-accordion/d2l-accordion.js';
-import 'd2l-accordion/d2l-accordion-collapse.js';
+import '@brightspace-ui-labs/accordion/accordion.js';
+import '@brightspace-ui-labs/accordion/accordion-collapse.js';
 import 'd2l-icons/d2l-icon.js';
 import 'd2l-icons/tier3-icons.js';
 
@@ -47,7 +47,7 @@ window.customElements.define('d2l-rubric-adapter', class RubricAdapter extends P
 					font-size: 0.8rem;
 				}
 
-				d2l-accordion-collapse[opened] .rubric-header-out-of-text {
+				d2l-labs-accordion-collapse[opened] .rubric-header-out-of-text {
 					display: none;
 				}
 			</style>
@@ -59,8 +59,8 @@ window.customElements.define('d2l-rubric-adapter', class RubricAdapter extends P
 					id="compact-view-template"
 					if="[[compact]]"
 					restamp>
-					<d2l-accordion flex>
-						<d2l-accordion-collapse flex>
+					<d2l-labs-accordion flex>
+						<d2l-labs-accordion-collapse flex>
 							<div slot="header">
 								<d2l-icon
 									class="rubric-header-icon"
@@ -76,8 +76,8 @@ window.customElements.define('d2l-rubric-adapter', class RubricAdapter extends P
 								</span>
 							</div>
 							<slot></slot>
-						</d2l-accordion-collapse>
-					</d2l-accordion>
+						</d2l-labs-accordion-collapse>
+					</d2l-labs-accordion>
 				</template>
 				<template is="dom-if" if="[[!compact]]" restamp>
 					<slot></slot>
@@ -108,7 +108,7 @@ window.customElements.define('d2l-rubric-adapter', class RubricAdapter extends P
 		const domIf = this.$['compact-view-template'];
 
 		domIf.addEventListener('dom-change', () => {
-			const accordion = this.shadowRoot.querySelector('d2l-accordion-collapse');
+			const accordion = this.shadowRoot.querySelector('d2l-labs-accordion-collapse');
 
 			if (accordion) {
 				if (this.___accordionMutationObserver) {

--- a/editor/d2l-rubric-editor.js
+++ b/editor/d2l-rubric-editor.js
@@ -13,7 +13,7 @@ import './d2l-rubric-editor-header.js';
 import '../localize-behavior.js';
 import './d2l-rubric-dropdown-menu-behavior.js';
 import { IronA11yAnnouncer } from '@polymer/iron-a11y-announcer/iron-a11y-announcer.js';
-import 'd2l-accordion/d2l-accordion-collapse.js';
+import '@brightspace-ui-labs/accordion/accordion-collapse.js';
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import 'd2l-tooltip/d2l-tooltip.js';
@@ -298,7 +298,7 @@ const $_documentContainer = html `
 		</template>
 
 		<div id="accordion-container">
-			<d2l-accordion-collapse title="[[localize('options')]]" flex="" opened$="[[_isReadOnly]]">
+			<d2l-labs-accordion-collapse title="[[localize('options')]]" flex="" opened$="[[_isReadOnly]]">
 				<div id="options-container">
 					<div id="visibility-container">
 						<d2l-rubric-visibility-editor href="[[href]]" token="[[token]]"></d2l-rubric-visibility-editor>
@@ -373,7 +373,7 @@ const $_documentContainer = html `
 						</template>
 					</div>
 				</div>
-			</d2l-accordion-collapse>
+			</d2l-labs-accordion-collapse>
 		</div>
 	</template>
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@polymer/iron-overlay-behavior": "^3.0.2",
     "@polymer/iron-resizable-behavior": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
-    "d2l-accordion": "BrightspaceUI/accordion#semver:^1",
+    "@brightspace-ui-labs/accordion": "^2.0.2",
     "d2l-activity-alignments": "Brightspace/d2l-activity-alignments.git#semver:^1",
     "d2l-alert": "BrightspaceUI/alert#semver:^4",
     "d2l-button": "BrightspaceUI/button#semver:^5",


### PR DESCRIPTION
The accordion component just got moved over into the "Labs" organization. This updates rubrics to use it, and [there's another PR open to update the other usage in sequences](https://github.com/BrightspaceHypermediaComponents/sequences/pull/179). This way, the next person who wants to make a change to accordion won't have to deal with this switchover.