### PR TITLE
Add set width to hierarchical overlay

### DIFF
--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -93,6 +93,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 				flex-direction: row;
 			}
 
+			#hierarchicaloverlay {
+				width: 50%;
+			}
+
 			#outcometag:not([hidden]){
 				border-left: 1px solid var(--d2l-color-galena);
 				margin-right: 50px;

--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -94,7 +94,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 			}
 
 			#hierarchicaloverlay {
-				width: 50%;
+				width: 800px;
 			}
 
 			#outcometag:not([hidden]){


### PR DESCRIPTION
When collapsing/expanding a node in outcomes hierarchy, the width can change depending on the length of the text of the non-hidden nodes. Adding a set width of 800px (similar to the MVC dialog) fixes this. `simple-overlay` deals with the max-width of the compoent.