### PR TITLE
Replace invalid tooltip boundary with align start

### DIFF
--- a/d2l-rubric-editable-score.js
+++ b/d2l-rubric-editable-score.js
@@ -124,7 +124,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-editable-score">
 				</div>
 			</template>
 		</div>
-		<d2l-tooltip aria-hidden="true" id="override-tooltip" hidden="[[_handleTooltip(scoreOverridden, _isEditingScore)]]" for="editable-container" position="top">[[_localizeStarLabel(totalScore)]]</d2l-tooltip>
+		<d2l-tooltip aria-hidden="true" align="start" hidden="[[_handleTooltip(scoreOverridden, _isEditingScore)]]" position="top">[[_localizeStarLabel(totalScore)]]</d2l-tooltip>
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);
@@ -224,12 +224,6 @@ Polymer({
 		'_updateAssessable(readOnly, assessmentHref)'
 	],
 	ready: function() {
-		if (!this.compact && this.criterionHref) {
-			this.$['override-tooltip'].setAttribute(
-				'boundary',
-				'{left: 0, right: 200}');
-		}
-
 		['click', 'keydown'].forEach((eventType) => {
 			this.addEventListener(eventType, (e) => {
 				if (eventType === 'keydown' && e.keyCode !== 13) {


### PR DESCRIPTION
# Changes
- The `d2l-tooltip` `boundary` was being set with an invalid boundary causing a Lit `Json.parse` exception. The original boundary was never valid, it just happened to cause undefined behavior in the old tooltip that caused it to position somewhat correctly.
- This replaces the invalid boundary with `align` start so that the tooltip is aligned correctly and now properly opens when tabbing through.

## Old
![rubrics-old](https://user-images.githubusercontent.com/11379933/78813551-2ff99900-799b-11ea-84d7-54bd859e8f99.gif)

## New 
![rubrics-new](https://user-images.githubusercontent.com/11379933/78813555-338d2000-799b-11ea-8f13-7b41cdd7689b.gif)
