### PR TITLE
US114949 - Remove telemetry-flag attribute

### DIFF
--- a/d2l-rubric.js
+++ b/d2l-rubric.js
@@ -350,11 +350,6 @@ Polymer({
 			type: String,
 			value: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPg0KICA8ZGVmcz4NCiAgICA8cGF0aCBpZD0iYSIgZD0iTTAgMGgyNHYyNEgweiIvPg0KICA8L2RlZnM+DQogIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xIC0xKSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4NCiAgICA8bWFzayBpZD0iYiIgZmlsbD0iI2ZmZiI+DQogICAgICA8dXNlIHhsaW5rOmhyZWY9IiNhIi8+DQogICAgPC9tYXNrPg0KICAgIDxwYXRoIGQ9Ik02IDIyLjY2N0E0LjY2NyA0LjY2NyAwIDAgMCAxMC42NjcgMThjMC0xLjIyNy0uNTU5LTIuNS0xLjMzNC0zLjMzM0M4LjQ4MSAxMy43NSA3LjM1IDEzLjMzMyA2IDEzLjMzM2MtLjQxMSAwIDEuMzMzLTYuNjY2IDMtOSAxLjY2Ny0yLjMzMyAxLjMzMy0zIC4zMzMtM0M4IDEuMzMzIDUuMjUzIDQuNTg2IDQgNy4yNTUgMS43NzMgMTIgMS4zMzMgMTUuMzkyIDEuMzMzIDE4QTQuNjY3IDQuNjY3IDAgMCAwIDYgMjIuNjY3ek0xOCAyMi42NjdBNC42NjcgNC42NjcgMCAwIDAgMjIuNjY3IDE4YzAtMS4yMjctLjU1OS0yLjUtMS4zMzQtMy4zMzMtLjg1Mi0uOTE3LTEuOTgzLTEuMzM0LTMuMzMzLTEuMzM0LS40MTEgMCAxLjMzMy02LjY2NiAzLTkgMS42NjctMi4zMzMgMS4zMzMtMyAuMzMzLTMtMS4zMzMgMC00LjA4IDMuMjUzLTUuMzMzIDUuOTIyQzEzLjc3MyAxMiAxMy4zMzMgMTUuMzkyIDEzLjMzMyAxOEE0LjY2NyA0LjY2NyAwIDAgMCAxOCAyMi42Njd6IiBmaWxsPSIjRDNEOUUzIiBtYXNrPSJ1cmwoI2IpIi8+DQogIDwvZz4NCjwvc3ZnPg=='
 		},
-		telemetryFlag: {
-			type: Boolean,
-			value: false,
-			reflectToAttribute: true,
-		},
 		performanceTelemetryFlag: {
 			type: Boolean,
 			value: false,
@@ -388,10 +383,7 @@ Polymer({
 		this._updateOutcomesTitleText();
 		this.perfMark('rubricLoadStart');
 
-		var telemetryEndpoint = null;
-		if (this.telemetryFlag) {
-			telemetryEndpoint = window.document.documentElement.dataset.telemetryEndpoint;
-		}
+		var telemetryEndpoint = window.document.documentElement.dataset.telemetryEndpoint;
 
 		this._telemetryData = {
 			rubricMode: this.dataset.rubricMode,

--- a/demo/index.html
+++ b/demo/index.html
@@ -80,7 +80,6 @@
 			token="foozleberries"
 			data-origin-tool="grades"
 			data-rubric-mode="graded"
-			telemetry-flag=""
 			outcomes-title-text="Standards"
 		></d2l-rubric>
 	</demo-snippet>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-rubric",
   "name": "d2l-rubric",
-  "version": "3.7.13",
+  "version": "3.7.15",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
[US114949](https://rally1.rallydev.com/#/detail/userstory/378530003388?fdp=true): LD Flag Cleanup - rubrics-telemetry

Another PR will be made on the LMS side to remove the `rubrics-telemetry` feature.