### PR TITLE
DE40414 - Holistic Rubrics with No Score crash mobile view

### DIFF
--- a/d2l-rubric-criteria-group-mobile.js
+++ b/d2l-rubric-criteria-group-mobile.js
@@ -86,7 +86,6 @@ Polymer({
 		this._name = entity.properties.name;
 		this._levelsHref = this._getLevelsLink(entity);
 		this._criteriaHref = this._getCriteriaLink(entity);
-		this._isHolistic = entity.hasClass(this.HypermediaClasses.rubrics.percentage);
 		this._isNumeric = entity.hasClass(this.HypermediaClasses.rubrics.numeric);
 	},
 

--- a/d2l-rubric-criteria-groups.js
+++ b/d2l-rubric-criteria-groups.js
@@ -64,6 +64,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criteria-groups">
 					criterion-result-map="[[_criterionResultMap]]"
 					cell-assessment-map="[[_cellAssessmentMap]]"
 					enable-feedback-copy="[[enableFeedbackCopy]]"
+					is-holistic="[[_isHolistic(rubricType)]]"
 				></d2l-rubric-criteria-group-mobile>
 				<slot></slot>
 			</template>
@@ -152,5 +153,9 @@ Polymer({
 			}
 		});
 		return criterionHrefs;
+	},
+
+	_isHolistic: function(rubricType) {
+		return rubricType === 'holistic';
 	}
 });


### PR DESCRIPTION
[DE40414](https://rally1.rallydev.com/#/detail/defect/424405440612?fdp=true) - We encountered this error in FACE since we use the mobile view there. It was escalated into this defect.

This fix updates the isHolistic property in `d2l-criteria-group-mobile` to more correctly be "IsHolistic" instead of what it was before which would have been more appropriately named "IsPercentage".

If this has potential to cause harm since we are changing what this IsHolistic means please advise, or let me know of anything else that I haven't thought of as I haven't touched much rubrics before, though I did have the guidance of Kieran.