### PR TITLE
DE40503 - Preserve feedback focus state when cell is assessed

### DIFF
--- a/d2l-rubric-criteria-group.js
+++ b/d2l-rubric-criteria-group.js
@@ -338,7 +338,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criteria-group">
 								data-criterion$="[[criterionNum]]"
 								on-save-feedback-start="_handleSaveStart"
 								on-save-feedback-finished="_handleSaveFinished"
-								on-close-feedback="_closeFeedback">
+								on-close-feedback="_closeFeedback"
+								on-focus="_handleFeedbackTextFocus">
 							</d2l-rubric-feedback>
 						</d2l-tspan>
 					</template>
@@ -854,7 +855,9 @@ Polymer({
 		this.CriterionCellAssessmentHelper.selectAsync(
 			() => this._lookupMap(event.model.get('criterionCell'), this.cellAssessmentMap)
 		).then(() => {
-			this._focusCriterionCell(event);
+			if (this._addingFeedback === -1) {
+				this._focusCriterionCell(event);
+			}
 
 			this.perfMark(`criterionCellTappedEnd-${uuid}`);
 			this.logCriterionCellTappedAction(`criterionCellTappedStart-${uuid}`, `criterionCellTappedEnd-${uuid}`);
@@ -923,6 +926,11 @@ Polymer({
 
 	_handleVisibleFeedbackFocusout: function(event) {
 		event.target.classList.remove('feedback-button-focused');
+	},
+
+	_handleFeedbackTextFocus: function(event) {
+		var criterionNum = event.model.get('criterionNum');
+		this._addingFeedback = criterionNum;
 	},
 
 	_focusCriterionCell: function(event) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-rubric",
   "name": "d2l-rubric",
-  "version": "3.7.31",
+  "version": "3.7.33",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Evaluating a cell and adding feedback before the API call has returned causes the feedback box to lose state. There now exists a check upon the return of the API call to see if the user is currently adding feedback.
https://rally1.rallydev.com/#/detail/defect/432474477752?fdp=true