### PR TITLE
tooltip: add announced attribute to d2l-tooltip occurrences that previously used announce helper

### DIFF
--- a/d2l-rubric-editable-score.js
+++ b/d2l-rubric-editable-score.js
@@ -119,7 +119,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-editable-score">
 					<div id="out-of">[[_localizeOutOf(entity)]]</div>
 				</div>
 				<template is="dom-if" if="[[scoreInvalid]]">
-					<d2l-tooltip id="score-bubble" for="text-area" class="is-error" position="bottom">[[scoreInvalidError]]</d2l-tooltip>
+					<d2l-tooltip announced id="score-bubble" for="text-area" class="is-error" position="bottom">[[scoreInvalidError]]</d2l-tooltip>
 				</template>
 			</div>
 			<template is="dom-if" if="[[!_isEditingScore]]">

--- a/d2l-rubric-feedback.js
+++ b/d2l-rubric-feedback.js
@@ -149,7 +149,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-feedback">
 				<d2l-input-textarea no-border$="[[!compact]]" no-padding$="[[!compact]]" id="text-area" value="{{_feedback}}" on-input="_handleInputChange" aria-invalid="[[isAriaInvalid(_feedbackInvalid)]]" on-focusin="_onFocusInTextArea" aria-label="[[_ariaLabelForTextArea]]">
 				</d2l-input-textarea>
 				<template is="dom-if" if="[[_feedbackInvalid]]">
-					<d2l-tooltip id="feedback-bubble" hidden=[[!_feedbackInFocus]] class="is-error" for="text-area" position="top">
+					<d2l-tooltip announced id="feedback-bubble" hidden=[[!_feedbackInFocus]] class="is-error" for="text-area" position="top">
 						[[_feedbackInvalidError]]
 					</d2l-tooltip>
 				</template>

--- a/editor/d2l-rubric-alignment-editor.js
+++ b/editor/d2l-rubric-alignment-editor.js
@@ -65,7 +65,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-alignment-editor">
 				</label>
 			</div>
 			<template is="dom-if" if="[[_alignmentInvalid]]">
-				<d2l-tooltip id="alignment-bubble" class="is-error" position="bottom">[[_alignmentInvalidError]]</d2l-tooltip>
+				<d2l-tooltip announced id="alignment-bubble" class="is-error" position="bottom">[[_alignmentInvalidError]]</d2l-tooltip>
 			</template>
 		</div>
 	</template>

--- a/editor/d2l-rubric-criteria-group-editor.js
+++ b/editor/d2l-rubric-criteria-group-editor.js
@@ -138,7 +138,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criteria-group-edito
 				>
 				</d2l-rubric-loa-overlay>
 				<template is="dom-if" if="[[_nameInvalid]]">
-					<d2l-tooltip id="group-name-bubble" class="is-error" for="group-name" position="bottom">
+					<d2l-tooltip announced id="group-name-bubble" class="is-error" for="group-name" position="bottom">
 						[[_nameInvalidError]]
 					</d2l-tooltip>
 				</template>

--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -278,7 +278,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 					</d2l-input-textarea>
 					<d2l-button-subtle id= "browseOutcomesButton" hidden$="[[_hideBrowseOutcomesButton]]" type="button" on-click= "_showBrowseOutcomes" text="[[outcomesTitle]]"></d2l-button-subtle>
 					<template is="dom-if" if="[[_nameInvalid]]">
-						<d2l-tooltip id="criterion-name-bubble" class="is-error" for="name" position="bottom">
+						<d2l-tooltip announced id="criterion-name-bubble" class="is-error" for="name" position="bottom">
 							[[_nameInvalidError]]
 						</d2l-tooltip>
 					</template>
@@ -322,7 +322,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 								editing="{{_outOfChanging}}"
 							></d2l-rubric-autosaving-input>
 							<template is="dom-if" if="[[_outOfInvalid]]">
-								<d2l-tooltip id="out-of-bubble" class="is-error" for="out-of-textbox" position="bottom">
+								<d2l-tooltip announced id="out-of-bubble" class="is-error" for="out-of-textbox" position="bottom">
 									[[_outOfInvalidError]]
 								</d2l-tooltip>
 							</template>

--- a/editor/d2l-rubric-description-editor.js
+++ b/editor/d2l-rubric-description-editor.js
@@ -1,5 +1,4 @@
 import '@polymer/polymer/polymer-legacy.js';
-import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import 'd2l-hypermedia-constants/d2l-hypermedia-constants.js';
 import 'd2l-tooltip/d2l-tooltip.js';
 import 'd2l-inputs/d2l-input-text.js';
@@ -123,12 +122,12 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-description-editor">
 			rich-text-enabled="[[_richTextAndEditEnabled(richTextEnabled,_canEditDescription)]]">
 		</d2l-rubric-text-editor>
 		<template is="dom-if" if="[[_descriptionInvalid]]">
-			<d2l-tooltip id="description-bubble" class="is-error" for="description" position="bottom">
+			<d2l-tooltip announced id="description-bubble" class="is-error" for="description" position="bottom">
 				[[_descriptionInvalidError]]
 			</d2l-tooltip>
 		</template>
 		<template is="dom-if" if="[[_pointsInvalid]]">
-			<d2l-tooltip id="cell-points-bubble" for="cell-points" position="bottom">
+			<d2l-tooltip announced id="cell-points-bubble" for="cell-points" position="bottom">
 				[[_pointsInvalidError]]
 			</d2l-tooltip>
 		</template>
@@ -322,8 +321,6 @@ Polymer({
 		if (action) {
 			if (this._pointsRequired && !saveEvent.value.trim()) {
 				this.toggleBubble('_pointsInvalid', true, 'cell-points-bubble', this.localize('pointsAreRequired'));
-
-				announce(this.localize('pointsAreRequired'));
 			} else {
 				this.toggleBubble('_pointsInvalid', false, 'cell-points-bubble');
 				var fields = [{ 'name': 'points', 'value': saveEvent.value }];

--- a/editor/d2l-rubric-editor.js
+++ b/editor/d2l-rubric-editor.js
@@ -280,7 +280,7 @@ const $_documentContainer = html `
 					editing="{{_nameChanging}}"
 				></d2l-rubric-autosaving-input>
 				<template is="dom-if" if="[[_nameInvalid]]">
-					<d2l-tooltip id="name-bubble" class="is-error" for="rubric-name" position="bottom">
+					<d2l-tooltip announced id="name-bubble" class="is-error" for="rubric-name" position="bottom">
 						[[_nameInvalidError]]
 					</d2l-tooltip>
 				</template>
@@ -313,7 +313,7 @@ const $_documentContainer = html `
 							[[localize('hideScore')]]
 						</d2l-input-checkbox>
 						<template is="dom-if" if="[[_setScoreVisibilityFailed]]">
-							<d2l-tooltip id="hide-score-bubble" class="is-error" for="hide-score-checkbox" position="bottom">
+							<d2l-tooltip announced id="hide-score-bubble" class="is-error" for="hide-score-checkbox" position="bottom">
 								[[_setScoreVisibilityFailedError]]
 							</d2l-tooltip>
 						</template>
@@ -325,7 +325,7 @@ const $_documentContainer = html `
 							<d2l-rubric-text-editor id="rubric-description" key="[[_getSelfLink(entity)]]" token="[[token]]" aria-invalid="[[isAriaInvalid(_descriptionInvalid)]]" aria-label$="[[localize('description')]]" disabled="[[!_canEditDescription]]" value="{{_rubricDescription}}" input-changing="{{_descriptionChanging}}" pending-saves="[[_pendingDescriptionSaves]]" on-text-changed="_saveDescription" rich-text-enabled="[[_richTextAndEditEnabled(richTextEnabled,_canEditDescription)]]">
 							</d2l-rubric-text-editor>
 							<template is="dom-if" if="[[_descriptionInvalid]]">
-								<d2l-tooltip id="rubric-description-bubble" class="is-error" for="rubric-description" position="bottom">
+								<d2l-tooltip announced id="rubric-description-bubble" class="is-error" for="rubric-description" position="bottom">
 									[[_descriptionInvalidError]]
 								</d2l-tooltip>
 							</template>
@@ -357,7 +357,7 @@ const $_documentContainer = html `
 								</template>
 							</div>
 							<template is="dom-if" if="[[_associationsInvalid]]">
-								<d2l-tooltip id="associations-bubble" class="is-error" for="associations" position="bottom">
+								<d2l-tooltip announced id="associations-bubble" class="is-error" for="associations" position="bottom">
 									[[_associationsInvalidError]]
 								</d2l-tooltip>
 							</template>
@@ -371,7 +371,7 @@ const $_documentContainer = html `
 						<label>[[localize('makeRubricAvailableHeader')]]</label>
 						<d2l-organization-availability-set token="[[token]]" href="[[_orgUnitAvailabilitySetLink]]" aria-invalid$="[[isAriaInvalid(_shareRubricInvalid)]]"></d2l-organization-availability-set>
 						<template is="dom-if" if="[[_shareRubricInvalid]]">
-							<d2l-tooltip id="share-rubric-bubble" class="is-error" for="make-rubric-available-container" position="bottom">
+							<d2l-tooltip announced id="share-rubric-bubble" class="is-error" for="make-rubric-available-container" position="bottom">
 								[[_shareRubricInvalidError]]
 							</d2l-tooltip>
 						</template>

--- a/editor/d2l-rubric-error-handling-behavior.js
+++ b/editor/d2l-rubric-error-handling-behavior.js
@@ -1,5 +1,4 @@
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
-import { announce } from '@brightspace-ui/core/helpers/announce.js';
 
 import '../localize-behavior.js';
 
@@ -34,8 +33,6 @@ D2L.PolymerBehaviors.Rubric.ErrorHandlingBehavior = {
 	handleValidationError: function(bubbleId, property, langterm, error) {
 		var msgText = this._getErrMsg(error, langterm);
 		this.toggleBubble(property, true, bubbleId, msgText);
-
-		announce(msgText);
 	},
 	_getErrMsg: function(e, altMsg) {
 		if (e && !e.hasOwnProperty('stack')) {

--- a/editor/d2l-rubric-feedback-editor.js
+++ b/editor/d2l-rubric-feedback-editor.js
@@ -51,7 +51,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-feedback-editor">
 			rich-text-enabled="[[_richTextAndEditEnabled(entity, richTextEnabled,_canEdit)]]">
 		</d2l-rubric-text-editor>
 		<template is="dom-if" if="[[_feedbackInvalid]]">
-			<d2l-tooltip id="feedback-bubble" class="is-error" for="feedback" position="bottom">
+			<d2l-tooltip announced id="feedback-bubble" class="is-error" for="feedback" position="bottom">
 				[[_feedbackInvalidError]]
 			</d2l-tooltip>
 		</template>

--- a/editor/d2l-rubric-level-editor.js
+++ b/editor/d2l-rubric-level-editor.js
@@ -100,12 +100,12 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-level-editor">
 			</d2l-button-icon>
 		</div>
 		<template is="dom-if" if="[[_nameInvalid]]">
-			<d2l-tooltip id="level-name-bubble" class="is-error" for="level-name" position="bottom">
+			<d2l-tooltip announced id="level-name-bubble" class="is-error" for="level-name" position="bottom">
 				[[_nameInvalidError]]
 			</d2l-tooltip>
 		</template>
 		<template is="dom-if" if="[[_pointsInvalid]]">
-			<d2l-tooltip id="points-bubble" for="level-points" position="bottom">
+			<d2l-tooltip announced id="points-bubble" for="level-points" position="bottom">
 				[[_pointsInvalidError]]
 			</d2l-tooltip>
 		</template>

--- a/editor/d2l-rubric-overall-level-editor.js
+++ b/editor/d2l-rubric-overall-level-editor.js
@@ -86,12 +86,12 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-overall-leve
 			</d2l-button-icon>
 		</div>
 		<template is="dom-if" if="[[_nameInvalid]]">
-			<d2l-tooltip id="overall-level-name-bubble" class="is-error" for="overall-level-name" position="bottom">
+			<d2l-tooltip announced id="overall-level-name-bubble" class="is-error" for="overall-level-name" position="bottom">
 				[[_nameInvalidError]]
 			</d2l-tooltip>
 		</template>
 		<template is="dom-if" if="[[_rangeStartInvalid]]">
-			<d2l-tooltip id="range-start-bubble" for="range-start" position="bottom">
+			<d2l-tooltip announced id="range-start-bubble" for="range-start" position="bottom">
 				[[_rangeStartInvalidError]]
 			</d2l-tooltip>
 		</template>

--- a/editor/d2l-rubric-visibility-editor.js
+++ b/editor/d2l-rubric-visibility-editor.js
@@ -83,7 +83,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-visibility-e
 			</label>
 		</div>
 		<template is="dom-if" if="[[_visibilityInvalid]]">
-			<d2l-tooltip id="visibility-bubble" class="is-error" position="bottom">[[_visibilityInvalidError]]</d2l-tooltip>
+			<d2l-tooltip announced id="visibility-bubble" class="is-error" position="bottom">[[_visibilityInvalidError]]</d2l-tooltip>
 		</template>
 	</template>
 </dom-module>`;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-rubric",
   "name": "d2l-rubric",
-  "version": "3.7.33",
+  "version": "3.7.34",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Context: `announce` is now being used in `d2l-tooltip` when the `announced` attribute is present. The attribute was added so that we could move the handling of announcing tooltip content from consumers into the tooltip while avoiding duplication.

I modified the usages that I could find that would have been announced currently (mostly by the error handling).