### PR TITLE
US120552 - Clean up RubricRendered event from telemetry

### DIFF
--- a/d2l-rubric-criteria-group.js
+++ b/d2l-rubric-criteria-group.js
@@ -555,11 +555,6 @@ Polymer({
 	},
 
 	_onCriterionCellDomChanged: function() {
-		const self = this;
-		this.perfMark('rubricRenderEnd');
-		this.debounce('criterionCellDomChangedEvent', function() {
-			self.logRubricRenderedEvent('rubricRenderStart', 'rubricRenderEnd');
-		}, 100);
 		this.markRubricLoadedEventEnd('rubric');
 	},
 

--- a/d2l-rubric.js
+++ b/d2l-rubric.js
@@ -400,10 +400,6 @@ Polymer({
 
 	_onEntityChanged: function(entity) {
 		if (entity) {
-			if (this._showContent === false) {
-				this.perfMark('rubricRenderStart');
-			}
-
 			this.rubricType = this._findRubricType(entity);
 			this.enableFeedbackCopy = this._getEnableFeedbackCopy(entity);
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-rubric",
   "name": "d2l-rubric",
-  "version": "3.7.34",
+  "version": "3.7.35",
   "directories": {
     "test": "test"
   },

--- a/telemetry-behavior.js
+++ b/telemetry-behavior.js
@@ -99,16 +99,6 @@ D2L.PolymerBehaviors.Rubric.TelemetryBehaviorImpl = {
 		}, this.telemetryData);
 	},
 
-	logRubricRenderedEvent: function(startMark, endMark) {
-		// Logs from render started (after receiving response) -> render finished
-		return this._logAndDestroyPerformanceEvent({
-			viewName: 'Rubric',
-			startMark: startMark,
-			endMark: endMark,
-			actionName: 'RubricRendered'
-		}, this.telemetryData);
-	},
-
 	logJavascriptError: function(message, error, source, line, column) {
 		const errorInfo = {
 			Name: (error && typeof error['name'] === 'string') ? error.name : typeof error,


### PR DESCRIPTION
Remove the `RubricRendered` event and its corresponding startMark and endMark (`rubricRenderStart` and `rubricRenderEnd`)
https://rally1.rallydev.com/#/detail/userstory/435810426628?fdp=true