### PR TITLE
Update telemetry-behavior.js

### DIFF
--- a/telemetry-behavior.js
+++ b/telemetry-behavior.js
@@ -258,7 +258,8 @@ D2L.PolymerBehaviors.Rubric.TelemetryBehaviorImpl = {
 					!errorEvent ||
 					(errorEvent.error && errorEvent.error['name'] === 'NetworkError') ||
 					// The ResizeObserver "error" isn't a true error. Ignore it
-					errorEvent.message === 'ResizeObserver loop completed with undelivered notifications.'
+					errorEvent.message === 'ResizeObserver loop completed with undelivered notifications.' ||
+					errorEvent.message === 'ResizeObserver loop limit exceeded'
 				) return;
 
 				this.logJavascriptError(


### PR DESCRIPTION
I was looking at there error logs and there are a number of these errors, but it seems like it should be warning and not an error and so ok to ignore https://github.com/WICG/resize-observer/issues/38