### PR TITLE
Update to use d2l-input-textarea from core.

### DIFF
--- a/d2l-rubric-feedback.js
+++ b/d2l-rubric-feedback.js
@@ -5,7 +5,7 @@ import './editor/d2l-rubric-error-handling-behavior.js';
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import 's-html/s-html.js';
-import 'd2l-inputs/d2l-input-textarea.js';
+import '@brightspace-ui/core/components/inputs/input-textarea.js';
 import './rubric-siren-entity.js';
 import '@polymer/iron-media-query/iron-media-query.js';
 import 'd2l-icons/d2l-icon.js';
@@ -127,7 +127,9 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-feedback">
 				display: flex;
 				padding: 18px
 			}
-
+			d2l-input-textarea {
+				margin-bottom: 8px;
+			}
 		</style>
 		<rubric-siren-entity href="[[criterionAssessmentHref]]" token="[[token]]" entity="{{criterionAssessment}}"></rubric-siren-entity>
 		<rubric-siren-entity href="[[criterionHref]]" token="[[token]]" entity="{{criterionEntity}}"></rubric-siren-entity>
@@ -146,7 +148,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-feedback">
 					<d2l-icon aria-hidden="true" id="clear-feedback" class="clear-feedback-button" tabindex="-1" icon="d2l-tier1:close-small" on-click="_clearFeedbackHandler" on-focusin="_handleVisibleFocusin"></d2l-icon>
 					<d2l-tooltip for="clear-feedback" force-show="[[_handleTooltip(_clearFeedbackInFocus)]]" position="bottom">[[localize('clearFeedback')]]</d2l-tooltip>
 				</div>
-				<d2l-input-textarea no-border$="[[!compact]]" no-padding$="[[!compact]]" id="text-area" value="{{_feedback}}" on-input="_handleInputChange" aria-invalid="[[isAriaInvalid(_feedbackInvalid)]]" on-focusin="_onFocusInTextArea" aria-label="[[_ariaLabelForTextArea]]">
+				<d2l-input-textarea no-border$="[[!compact]]" no-padding$="[[!compact]]" rows="1" max-rows="-1" id="text-area" value="{{_feedback}}" on-input="_handleInputChange" aria-invalid="[[isAriaInvalid(_feedbackInvalid)]]" on-focusin="_onFocusInTextArea" aria-label="[[_ariaLabelForTextArea]]">
 				</d2l-input-textarea>
 				<template is="dom-if" if="[[_feedbackInvalid]]">
 					<d2l-tooltip announced id="feedback-bubble" hidden=[[!_feedbackInFocus]] class="is-error" for="text-area" position="top">
@@ -325,7 +327,7 @@ Polymer({
 
 	_saveFeedbackHandler: function(e) {
 		if (this._feedbackModified || !this._pendingFeedbackSaves && this._feedbackInvalid) {
-			var value = e.target.$.textarea.value;
+			var value = e.target.value;
 			this._saveFeedback(value);
 		}
 	},

--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -7,7 +7,7 @@ import 'd2l-activity-alignments/d2l-activity-alignment-tags.js';
 import 'd2l-table/d2l-table-shared-styles.js';
 import 'd2l-hypermedia-constants/d2l-hypermedia-constants.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
-import 'd2l-inputs/d2l-input-textarea.js';
+import '@brightspace-ui/core/components/inputs/input-textarea.js';
 import 'd2l-inputs/d2l-input-text.js';
 import 'd2l-button/d2l-button-icon.js';
 import 'd2l-tooltip/d2l-tooltip.js';
@@ -67,6 +67,9 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 				display: block;
 				flex-grow: 1;
 				width: 100%;
+				z-index: 0;
+				--d2l-input-border-radius: 0;
+				--d2l-input-border-color: transparent;
 			}
 
 			.criterion-feedback-header {
@@ -248,12 +251,12 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 			<slot name="gutter-left"></slot>
 		</div>
 
-		<d2l-dialog title-text="[[browseOutcomesText]]" id="overlay">	
+		<d2l-dialog title-text="[[browseOutcomesText]]" id="overlay">
 			<d2l-select-outcomes
-			  rel= "[[_getOutcomeRel(_isFlagOn, isHolistic)]]"
-              href="[[_getOutcomeHref(entity, _isFlagOn, isHolistic)]]"
-			  token="[[token]]"
-			  empty="{{_isOutcomeEmpty}}"
+				rel= "[[_getOutcomeRel(_isFlagOn, isHolistic)]]"
+				href="[[_getOutcomeHref(entity, _isFlagOn, isHolistic)]]"
+				token="[[token]]"
+				empty="{{_isOutcomeEmpty}}"
 			>
 			</d2l-select-outcomes>
 		</d2l-dialog>
@@ -274,7 +277,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 		<div style="display:flex; flex-direction:column;">
 			<div style="display:flex">
 				<div class="cell col-first criterion-name" hidden$="[[isHolistic]]">
-					<d2l-input-textarea id="name" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('criterionNameAriaLabel')]]" disabled="[[!_canEdit]]" value="{{_getDisplayedName(_nameFocused,_nameInvalid,_pendingNameSaves,_enteredName,_criterionName)}}" placeholder="[[_getNamePlaceholder(localize, displayNamePlaceholder)]]" on-blur="_nameBlurHandler" on-focus="_nameFocusHandler" on-input="_nameInputHandler">
+					<d2l-input-textarea id="name" aria-invalid="[[isAriaInvalid(_nameInvalid)]]" aria-label$="[[localize('criterionNameAriaLabel')]]" disabled="[[!_canEdit]]" max-rows="-1" value="{{_getDisplayedName(_nameFocused,_nameInvalid,_pendingNameSaves,_enteredName,_criterionName)}}" placeholder="[[_getNamePlaceholder(localize, displayNamePlaceholder)]]" on-blur="_nameBlurHandler" on-focus="_nameFocusHandler" on-input="_nameInputHandler">
 					</d2l-input-textarea>
 					<d2l-button-subtle id= "browseOutcomesButton" hidden$="[[_hideBrowseOutcomesButton]]" type="button" on-click= "_showBrowseOutcomes" text="[[outcomesTitle]]"></d2l-button-subtle>
 					<template is="dom-if" if="[[_nameInvalid]]">
@@ -546,7 +549,7 @@ Polymer({
 
 		if (!this.animating && !oldEntity) {
 			setTimeout(function() {
-				this.$$('#name').textarea.select();
+				this.$$('#name').select();
 				this._transitionElement(this, 10);
 				this.scrollIntoView();
 			}.bind(this));

--- a/editor/d2l-rubric-text-editor.js
+++ b/editor/d2l-rubric-text-editor.js
@@ -1,5 +1,5 @@
 import '@polymer/polymer/polymer-legacy.js';
-import 'd2l-inputs/d2l-input-textarea.js';
+import '@brightspace-ui/core/components/inputs/input-textarea.js';
 import './d2l-rubric-html-editor.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
@@ -15,13 +15,19 @@ Polymer({
 				display: none;
 			}
 
+			d2l-input-textarea {
+				width: 100%;
+				--d2l-input-border-radius: 0;
+				--d2l-input-border-color: transparent;
+			}
+
 			* {
 				box-sizing: border-box;
 			}
 
 		</style>
 		<template is="dom-if" if="[[!richTextEnabled]]">
-			<d2l-input-textarea id="textEditor" hidden$="[[richTextEnabled]]" aria-invalid="[[ariaInvalid]]" aria-label$="[[ariaLabel]]" disabled="[[disabled]]" value="{{value}}" on-blur="_onInputBlur" on-input="_duringInputChange"></d2l-input-textarea>
+			<d2l-input-textarea id="textEditor" hidden$="[[richTextEnabled]]" aria-invalid="[[ariaInvalid]]" aria-label$="[[ariaLabel]]" disabled="[[disabled]]" max-rows="-1" value="{{value}}" on-blur="_onInputBlur" on-input="_duringInputChange"></d2l-input-textarea>
 		</template>
 		<template is="dom-if" if="[[richTextEnabled]]">
 			<d2l-rubric-html-editor id="htmlEditor" token="[[token]]" hidden$="[[!richTextEnabled]]" aria-label$="[[ariaLabel]]" invalid="[[_stringIsTrue(ariaInvalid)]]" placeholder="[[placeholder]]" value="[[value]]" key="[[key]]" min-rows="[[minRows]]" max-rows="[[maxRows]]" on-change="_duringInputChange"></d2l-rubric-html-editor>

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@brightspace-ui-labs/accordion": "^2.0.2",
-    "@brightspace-ui/core": "^1.113.4",
+    "@brightspace-ui/core": "^1.113.5",
     "@polymer/iron-media-query": "^3.0.0",
     "@polymer/iron-overlay-behavior": "^3.0.2",
     "@polymer/iron-resizable-behavior": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-rubric",
   "name": "d2l-rubric",
-  "version": "3.7.38",
+  "version": "3.7.39",
   "directories": {
     "test": "test"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@brightspace-ui-labs/accordion": "^2.0.2",
-    "@brightspace-ui/core": "^1.30.1",
+    "@brightspace-ui/core": "^1.113.4",
     "@polymer/iron-media-query": "^3.0.0",
     "@polymer/iron-overlay-behavior": "^3.0.2",
     "@polymer/iron-resizable-behavior": "^3.0.0",


### PR DESCRIPTION
This PR updates to use d2l-input-textarea from core (however d2l-inputs will also be updated shortly to import from core as well), so this PR applies a couple of additional changes necessary to maintain the existing behaviour - see comments.