### PR TITLE
Fix rows for initial feedback.

### DIFF
--- a/editor/d2l-rubric-text-editor.js
+++ b/editor/d2l-rubric-text-editor.js
@@ -27,7 +27,7 @@ Polymer({
 
 		</style>
 		<template is="dom-if" if="[[!richTextEnabled]]">
-			<d2l-input-textarea id="textEditor" hidden$="[[richTextEnabled]]" aria-invalid="[[ariaInvalid]]" aria-label$="[[ariaLabel]]" disabled="[[disabled]]" max-rows="-1" value="{{value}}" on-blur="_onInputBlur" on-input="_duringInputChange"></d2l-input-textarea>
+			<d2l-input-textarea id="textEditor" hidden$="[[richTextEnabled]]" aria-invalid="[[ariaInvalid]]" aria-label$="[[ariaLabel]]" disabled="[[disabled]]" rows="1" max-rows="-1" value="{{value}}" on-blur="_onInputBlur" on-input="_duringInputChange"></d2l-input-textarea>
 		</template>
 		<template is="dom-if" if="[[richTextEnabled]]">
 			<d2l-rubric-html-editor id="htmlEditor" token="[[token]]" hidden$="[[!richTextEnabled]]" aria-label$="[[ariaLabel]]" invalid="[[_stringIsTrue(ariaInvalid)]]" placeholder="[[placeholder]]" value="[[value]]" key="[[key]]" min-rows="[[minRows]]" max-rows="[[maxRows]]" on-change="_duringInputChange"></d2l-rubric-html-editor>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-rubric",
   "name": "d2l-rubric",
-  "version": "3.7.39",
+  "version": "3.7.40",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
The default min rows changes between the Polymer and Lit versions of `d2l-input-textarea`.  Previously the default was 1 row, whereas with the Lit version the default is 5.  This PR fixes the height difference being observed by setting `rows="1"` to match previous behavior.