### PR TITLE
US124182 - Add button accessibility for inline feedback

### DIFF
--- a/build/lang/ar.js
+++ b/build/lang/ar.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.Ar = {
 	'changeRubricTypeWarnTitle': 'هل تريد تغيير نوع آلية التقييم؟',
 	'changeScoringSuccessful': 'تم تغيير طريقة وضع الدرجات إلى {method}',
 	'clearFeedback': 'مسح الملاحظات',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': 'مسح التجاوز',
 	'closeDialog': 'إغلاق',
 	'criteriaGroup': 'مجموعة المعايير',

--- a/build/lang/cy.js
+++ b/build/lang/cy.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.Cy = {
 	'changeRubricTypeWarnTitle': 'Newid math y gyfeireb?',
 	'changeScoringSuccessful': 'Mae’r dull sgorio wedi newid i {method}',
 	'clearFeedback': 'Clirio’r Adborth',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': 'Clirio’r Gwrth-wneud',
 	'closeDialog': 'Cau',
 	'criteriaGroup': 'Grŵp Meini Prawf',

--- a/build/lang/da.js
+++ b/build/lang/da.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.Da = {
 	'changeRubricTypeWarnTitle': 'Skal rubriktypen ændres?',
 	'changeScoringSuccessful': 'Scoremetode ændret til {method}',
 	'clearFeedback': 'Ryd feedback',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': 'Ryd tilsidesættelse',
 	'closeDialog': 'Luk',
 	'criteriaGroup': 'Kriteriegruppe',

--- a/build/lang/de.js
+++ b/build/lang/de.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.De = {
 	'changeRubricTypeWarnTitle': 'Bewertungsschema-Typ ändern?',
 	'changeScoringSuccessful': 'Bewertungsmethode zu {method} geändert',
 	'clearFeedback': 'Feedback löschen',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': 'Außerkraftsetzung aufheben',
 	'closeDialog': 'Schließen',
 	'criteriaGroup': 'Kriteriengruppe',

--- a/build/lang/en.js
+++ b/build/lang/en.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.En = {
 	'changeRubricTypeWarnTitle': 'Change rubric type?',
 	'changeScoringSuccessful': 'Scoring method changed to {method}',
 	'clearFeedback': 'Clear Feedback',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': 'Clear Override',
 	'closeDialog': 'Close',
 	'criteriaGroup': 'Criteria Group',

--- a/build/lang/es-es.js
+++ b/build/lang/es-es.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.EsEs = {
 	'changeRubricTypeWarnTitle': '¿Desea cambiar el tipo de rúbrica?',
 	'changeScoringSuccessful': 'Se ha cambiado el método de puntuación a {method}',
 	'clearFeedback': 'Borrar comentarios',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': 'Borrar anulación',
 	'closeDialog': 'Cerrar',
 	'criteriaGroup': 'Grupo de criterios',

--- a/build/lang/es.js
+++ b/build/lang/es.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.Es = {
 	'changeRubricTypeWarnTitle': '¿Desea cambiar el tipo de rúbrica?',
 	'changeScoringSuccessful': 'Se cambió el método de puntuación a {method}',
 	'clearFeedback': 'Borrar comentarios',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': 'Borrar anulación',
 	'closeDialog': 'Cerrar',
 	'criteriaGroup': 'Grupo de criterios',

--- a/build/lang/fr-fr.js
+++ b/build/lang/fr-fr.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.FrFr = {
 	'changeRubricTypeWarnTitle': 'Modifier le type de grille d’évaluation ?',
 	'changeScoringSuccessful': 'Méthode d’attribution de note remplacée par {method}',
 	'clearFeedback': 'Effacer la réaction',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': 'Effacer le remplacement',
 	'closeDialog': 'Fermer',
 	'criteriaGroup': 'Groupe de critères',

--- a/build/lang/fr.js
+++ b/build/lang/fr.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.Fr = {
 	'changeRubricTypeWarnTitle': 'Changer le type de grille d’évaluation?',
 	'changeScoringSuccessful': 'La méthode d’attribution du pointage a été changée à {method}',
 	'clearFeedback': 'Effacer la rétroaction',
+	'clearFeedbackFor': 'Rétroaction claire pour le critère {criterionName}',
 	'clearOverride': 'Effacer les remplacements',
 	'closeDialog': 'Fermer',
 	'criteriaGroup': 'Groupe de critères',

--- a/build/lang/ja.js
+++ b/build/lang/ja.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.Ja = {
 	'changeRubricTypeWarnTitle': '注釈タイプを変更しますか？',
 	'changeScoringSuccessful': 'スコアリング方法が {method} に変更されました',
 	'clearFeedback': 'フィードバックのクリア',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': '上書きのクリア',
 	'closeDialog': '閉じる',
 	'criteriaGroup': '条件グループ',

--- a/build/lang/ko.js
+++ b/build/lang/ko.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.Ko = {
 	'changeRubricTypeWarnTitle': '루브릭 유형을 변경하시겠습니까?',
 	'changeScoringSuccessful': '{method}(으)로 점수 산정법 변경됨',
 	'clearFeedback': '피드백 지우기',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': '재설정 지우기',
 	'closeDialog': '닫기',
 	'criteriaGroup': '기준 그룹',

--- a/build/lang/nl.js
+++ b/build/lang/nl.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.Nl = {
 	'changeRubricTypeWarnTitle': 'Rubrictype veranderen?',
 	'changeScoringSuccessful': 'Scoringsmethode is gewijzigd in {method}',
 	'clearFeedback': 'Feedback wissen',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': 'Overschrijven wissen',
 	'closeDialog': 'Sluiten',
 	'criteriaGroup': 'Criteriagroep',

--- a/build/lang/pt.js
+++ b/build/lang/pt.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.Pt = {
 	'changeRubricTypeWarnTitle': 'Alterar o tipo de rubrica?',
 	'changeScoringSuccessful': 'Método de pontuação alterado para {method}',
 	'clearFeedback': 'Limpar Comentário',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': 'Limpar Substituir',
 	'closeDialog': 'Fechar',
 	'criteriaGroup': 'Grupo de critérios',

--- a/build/lang/sv.js
+++ b/build/lang/sv.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.Sv = {
 	'changeRubricTypeWarnTitle': 'Ändra rubriceringstyp?',
 	'changeScoringSuccessful': 'Betygsättningsmetod ändrad till {method}',
 	'clearFeedback': 'Rensa feedback',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': 'Rensa åsidosättning',
 	'closeDialog': 'Stäng',
 	'criteriaGroup': 'Kriteriegrupp',

--- a/build/lang/tr.js
+++ b/build/lang/tr.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.Tr = {
 	'changeRubricTypeWarnTitle': 'Rubrik türü değiştirilsin mi?',
 	'changeScoringSuccessful': 'Puanlama yöntemi {method} olarak değiştirildi',
 	'clearFeedback': 'Geri Bildirimi Temizle',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': 'Etkisizleştirmeyi Temizle',
 	'closeDialog': 'Kapat',
 	'criteriaGroup': 'Ölçüt Grubu',

--- a/build/lang/zh-tw.js
+++ b/build/lang/zh-tw.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.ZhTw = {
 	'changeRubricTypeWarnTitle': '變更量規類型？',
 	'changeScoringSuccessful': '評分方法已變更為「{method}」',
 	'clearFeedback': '清除意見反應',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': '清除覆寫',
 	'closeDialog': '關閉',
 	'criteriaGroup': '標準群組',

--- a/build/lang/zh.js
+++ b/build/lang/zh.js
@@ -31,6 +31,7 @@ window.D2L.Rubric.Language.Zh = {
 	'changeRubricTypeWarnTitle': '更改量规类别？',
 	'changeScoringSuccessful': '评分方法更改为 {method}',
 	'clearFeedback': '清除反馈',
+	'clearFeedbackFor': 'Clear feedback for criterion {criterionName}',
 	'clearOverride': '清除改写',
 	'closeDialog': '关闭',
 	'criteriaGroup': '标准组',

--- a/d2l-rubric-criteria-mobile.js
+++ b/d2l-rubric-criteria-mobile.js
@@ -56,6 +56,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criteria-mobile">
 				class="add-feedback-button"
 				hidden="[[!_showAddFeedback(criterion, criterionResultMap, criterionNum, _addingFeedback, readOnly,  _savingFeedback.*, _feedbackInvalid.*)]]"
 				text="[[localize('addFeedback')]]"
+				description="[[_localizeAddFeedbackButtonDescription(criterion)]]"
 				on-click="_handleAddFeedback"
 				data-criterion$="[[criterionNum]]">
 			</d2l-button-subtle>
@@ -214,5 +215,13 @@ Polymer({
 		}
 		const entityHref = this._getSelfLink(entity);
 		return entityHref && map[entityHref];
+	},
+
+	_localizeAddFeedbackButtonDescription: function(criterion) {
+		if (!criterion || !criterion.properties || !criterion.properties.name) {
+			return null;
+		}
+
+		return this.localize('addFeedbackFor', 'criterionName', criterion.properties.name);
 	}
 });

--- a/d2l-rubric-feedback.js
+++ b/d2l-rubric-feedback.js
@@ -147,7 +147,15 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-feedback">
 							[[_feedbackHeadingExtra]]
 						</div>
 					</div>
-					<d2l-icon aria-hidden="true" id="clear-feedback" class="clear-feedback-button" tabindex="-1" icon="d2l-tier1:close-small" on-click="_clearFeedbackHandler" on-focusin="_handleVisibleFocusin"></d2l-icon>
+					<d2l-icon
+						aria-hidden="true"
+						id="clear-feedback"
+						class="clear-feedback-button"
+						tabindex="-1"
+						icon="d2l-tier1:close-small"
+						on-click="_clearFeedbackHandler"
+						on-focusin="_handleVisibleFocusin"
+					></d2l-icon>
 					<d2l-tooltip for="clear-feedback" force-show="[[_handleTooltip(_clearFeedbackInFocus)]]" position="bottom">[[localize('clearFeedback')]]</d2l-tooltip>
 				</div>
 				<d2l-input-textarea no-border$="[[!compact]]" no-padding$="[[!compact]]" rows="1" max-rows="-1" id="text-area" value="{{_feedback}}" on-input="_handleInputChange" aria-invalid="[[isAriaInvalid(_feedbackInvalid)]]" on-focusin="_onFocusInTextArea" aria-label="[[_ariaLabelForTextArea]]">
@@ -158,7 +166,13 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-feedback">
 					</d2l-tooltip>
 				</template>
 				<d2l-offscreen>
-					<d2l-button-subtle aria-label$="[[localize('clearFeedback')]]" id="clear-feedback-invisible" on-focusin="_handleInvisibleFocusin" on-focusout="_handleInvisibleFocusout" on-click="_clearFeedbackHandler">
+					<d2l-button-subtle
+						description="[[_localizeClearFeedbackButtonDescription(criterionEntity)]]"
+						id="clear-feedback-invisible"
+						on-focusin="_handleInvisibleFocusin"
+						on-focusout="_handleInvisibleFocusout"
+						on-click="_clearFeedbackHandler">
+					</d2l-button-subtle>
 				</d2l-offscreen>
 			</div>
 			<div hidden="[[_hasReadonlyFeedback(criterionEntity, criterionAssessment, addingFeedback)]]">
@@ -428,5 +442,13 @@ Polymer({
 		if (!criterionEntity) return;
 		const name = criterionEntity.properties && criterionEntity.properties.name || '';
 		return this.localize('feedbackOn', 'criterionName', name);
+	},
+
+	_localizeClearFeedbackButtonDescription: function(criterionEntity) {
+		if (!criterionEntity || !criterionEntity.properties || !criterionEntity.properties.name) {
+			return null;
+		}
+
+		return this.localize('clearFeedbackFor', 'criterionName', criterionEntity.properties.name);
 	}
 });

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "هل تريد تغيير نوع آلية التقييم؟",
     "changeScoringSuccessful": "تم تغيير طريقة وضع الدرجات إلى {method}",
     "clearFeedback": "مسح الملاحظات",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "مسح التجاوز",
     "closeDialog": "إغلاق",
     "criteriaGroup": "مجموعة المعايير",

--- a/lang/cy.json
+++ b/lang/cy.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "Newid math y gyfeireb?",
     "changeScoringSuccessful": "Mae’r dull sgorio wedi newid i {method}",
     "clearFeedback": "Clirio’r Adborth",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "Clirio’r Gwrth-wneud",
     "closeDialog": "Cau",
     "criteriaGroup": "Grŵp Meini Prawf",

--- a/lang/da.json
+++ b/lang/da.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "Skal rubriktypen ændres?",
     "changeScoringSuccessful": "Scoremetode ændret til {method}",
     "clearFeedback": "Ryd feedback",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "Ryd tilsidesættelse",
     "closeDialog": "Luk",
     "criteriaGroup": "Kriteriegruppe",

--- a/lang/de.json
+++ b/lang/de.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "Bewertungsschema-Typ ändern?",
     "changeScoringSuccessful": "Bewertungsmethode zu {method} geändert",
     "clearFeedback": "Feedback löschen",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "Außerkraftsetzung aufheben",
     "closeDialog": "Schließen",
     "criteriaGroup": "Kriteriengruppe",

--- a/lang/en.json
+++ b/lang/en.json
@@ -24,6 +24,7 @@
   "changeRubricTypeWarnTitle": "Change rubric type?",
   "changeScoringSuccessful": "Scoring method changed to {method}",
   "clearFeedback": "Clear Feedback",
+  "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
   "clearOverride": "Clear Override",
   "closeDialog": "Close",
   "criteriaGroup": "Criteria Group",

--- a/lang/es-es.json
+++ b/lang/es-es.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "¿Desea cambiar el tipo de rúbrica?",
     "changeScoringSuccessful": "Se ha cambiado el método de puntuación a {method}",
     "clearFeedback": "Borrar comentarios",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "Borrar anulación",
     "closeDialog": "Cerrar",
     "criteriaGroup": "Grupo de criterios",

--- a/lang/es.json
+++ b/lang/es.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "¿Desea cambiar el tipo de rúbrica?",
     "changeScoringSuccessful": "Se cambió el método de puntuación a {method}",
     "clearFeedback": "Borrar comentarios",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "Borrar anulación",
     "closeDialog": "Cerrar",
     "criteriaGroup": "Grupo de criterios",

--- a/lang/fr-fr.json
+++ b/lang/fr-fr.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "Modifier le type de grille d’évaluation ?",
     "changeScoringSuccessful": "Méthode d’attribution de note remplacée par {method}",
     "clearFeedback": "Effacer la réaction",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "Effacer le remplacement",
     "closeDialog": "Fermer",
     "criteriaGroup": "Groupe de critères",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "Changer le type de grille d’évaluation?",
     "changeScoringSuccessful": "La méthode d’attribution du pointage a été changée à {method}",
     "clearFeedback": "Effacer la rétroaction",
+    "clearFeedbackFor": "Rétroaction claire pour le critère {criterionName}",
     "clearOverride": "Effacer les remplacements",
     "closeDialog": "Fermer",
     "criteriaGroup": "Groupe de critères",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "注釈タイプを変更しますか？",
     "changeScoringSuccessful": "スコアリング方法が {method} に変更されました",
     "clearFeedback": "フィードバックのクリア",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "上書きのクリア",
     "closeDialog": "閉じる",
     "criteriaGroup": "条件グループ",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "루브릭 유형을 변경하시겠습니까?",
     "changeScoringSuccessful": "{method}(으)로 점수 산정법 변경됨",
     "clearFeedback": "피드백 지우기",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "재설정 지우기",
     "closeDialog": "닫기",
     "criteriaGroup": "기준 그룹",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "Rubrictype veranderen?",
     "changeScoringSuccessful": "Scoringsmethode is gewijzigd in {method}",
     "clearFeedback": "Feedback wissen",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "Overschrijven wissen",
     "closeDialog": "Sluiten",
     "criteriaGroup": "Criteriagroep",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "Alterar o tipo de rubrica?",
     "changeScoringSuccessful": "Método de pontuação alterado para {method}",
     "clearFeedback": "Limpar Comentário",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "Limpar Substituir",
     "closeDialog": "Fechar",
     "criteriaGroup": "Grupo de critérios",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "Ändra rubriceringstyp?",
     "changeScoringSuccessful": "Betygsättningsmetod ändrad till {method}",
     "clearFeedback": "Rensa feedback",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "Rensa åsidosättning",
     "closeDialog": "Stäng",
     "criteriaGroup": "Kriteriegrupp",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "Rubrik türü değiştirilsin mi?",
     "changeScoringSuccessful": "Puanlama yöntemi {method} olarak değiştirildi",
     "clearFeedback": "Geri Bildirimi Temizle",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "Etkisizleştirmeyi Temizle",
     "closeDialog": "Kapat",
     "criteriaGroup": "Ölçüt Grubu",

--- a/lang/zh-tw.json
+++ b/lang/zh-tw.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "變更量規類型？",
     "changeScoringSuccessful": "評分方法已變更為「{method}」",
     "clearFeedback": "清除意見反應",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "清除覆寫",
     "closeDialog": "關閉",
     "criteriaGroup": "標準群組",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -24,6 +24,7 @@
     "changeRubricTypeWarnTitle": "更改量规类别？",
     "changeScoringSuccessful": "评分方法更改为 {method}",
     "clearFeedback": "清除反馈",
+    "clearFeedbackFor": "Clear feedback for criterion {criterionName}",
     "clearOverride": "清除改写",
     "closeDialog": "关闭",
     "criteriaGroup": "标准组",


### PR DESCRIPTION
This adds better accessibility descriptions for the **Add Feedback** and **Clear Feedback** (**X**) buttons. They now read as `clickable Add feedback for criterion {criterion name} button` and `clickable Clear feedback for criterion {criterion name} button` respectively.