### PR TITLE
Fixed aria lable on firefox

### DIFF
--- a/d2l-rubric-alignments-indicator.js
+++ b/d2l-rubric-alignments-indicator.js
@@ -82,7 +82,7 @@ class RubricAlignmentsIndicator extends mixinBehaviors([
 </style>
 
 <template is="dom-if" if="[[_hasOutcomes(_outcomeMap)]]">
-	<d2l-icon aria-label="[[_getCriterionText(criterionName)]]" id="alignments-icon" tabindex="0" icon="d2l-tier1:bullseye"></d2l-icon>
+	<d2l-icon aria-label$="[[_getCriterionText(criterionName)]]" id="alignments-icon" tabindex="0" icon="d2l-tier1:bullseye"> </d2l-icon>
 	<d2l-tooltip for="alignments-icon" position="[[_getTooltipPosition(mobile)]]" force-show="[[_hasFocus]]">
 		<div><b>[[outcomesTitleText]]</b></div>
 		<template is="dom-repeat" items="[[_getTooltipOutcomes(_outcomeMap)]]">


### PR DESCRIPTION
Turns out you need to use a $= to set a tag, using = on a polymer component is setting a property, https://polymer-library.polymer-project.org/1.0/docs/devguide/data-binding. Chrome and Edge didn't seem to mind but Firefox needed to use $= for NVDA to pick up the tag 

https://rally1.rallydev.com/#/57732444928ud/custom/373260458992?detail=%2Fuserstory%2F388955114124