### PR TITLE
Try doubling test timeout

### DIFF
--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,4 +1,5 @@
 {
+  "testTimeout": 180000,
   "plugins": {
     "local": {
       "browsers": [


### PR DESCRIPTION
Default test timeout is 90 seconds and rubrics tests are super slow.