### PR TITLE
set shouldFocus to false after focusing on text area once

### DIFF
--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -593,6 +593,7 @@ Polymer({
 		}
 
 		if (!this.animating && this.shouldFocus) {
+			this.shouldFocus = false;
 			setTimeout(function() {
 				this.$$('#name').select();
 				this._transitionElement(this, 10);


### PR DESCRIPTION
This is the fix to 
https://rally1.rallydev.com/#/57732444928ud/defects?Name=Newly%20created%20criterion%20keep%20highlighting%20the%20text&Project=https%3A%2F%2Frally1.rallydev.com%2Fslm%2Fwebservice%2Fv2.x%2Fproject%2F57732444928&detail=%2Fdefect%2F506128829156&iteration=u&rankTo=BOTTOM

We should set `this.shouldFocus` to false after it is being initially focused once to avoid refocusing when criterion entity changes.