### PR TITLE
set maxHeight equal to null after transitionElement

### DIFF
--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -29,6 +29,7 @@ import './d2l-rubric-autosaving-input.js';
 import '../telemetry-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 const $_documentContainer = document.createElement('template');
+import 'fastdom/fastdom.js';
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 	<template strip-whitespace="">
@@ -597,6 +598,11 @@ Polymer({
 			setTimeout(function() {
 				this.$$('#name').select();
 				this._transitionElement(this, 10);
+
+				fastdom.mutate(function() {
+					this.style.maxHeight = null;
+				}.bind(this));
+
 				this.scrollIntoView();
 			}.bind(this));
 		} else {


### PR DESCRIPTION
This is the fix to 
https://rally1.rallydev.com/#/57732444928ud/defects?Name=Copied%20criterion%20can%20be%20missaligned%20with%20custom%20points&Project=https%3A%2F%2Frally1.rallydev.com%2Fslm%2Fwebservice%2Fv2.x%2Fproject%2F57732444928&detail=%2Fdefect%2F506134490844&iteration=u&rankTo=BOTTOM

**Cause of the Defect:**
- For some reasons when we are inserting a criterion in the middle, the event `transitionend` is not fired which causes the function `_transitionElement` from `d2l-rubric-entity-behaviour` to not run the part where it waits for such event and resets maxHeight to null. 

I am not sure where this event is fired in d2l-rubric as it is only declared and used in the function `_transitionElement`.  The event `transitionend` was successfully fired when we copy a criterion to the end of the criteria group but not when inserting in the middle.