### PR TITLE
Fix dialog width issues

### DIFF
--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -106,10 +106,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 				flex-direction: row;
 			}
 
-			#hierarchicaloverlay {
-				width: 800px;
-			}
-
 			#outcometag:not([hidden]){
 				border-left: 1px solid var(--d2l-color-galena);
 				margin-right: 50px;
@@ -275,7 +271,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 			</d2l-select-outcomes>
 		</d2l-dialog>
 
-		<d2l-dialog title-text="[[browseOutcomesText]]" id="hierarchicaloverlay">
+		<d2l-dialog title-text="[[browseOutcomesText]]" width="800" id="hierarchicaloverlay">
 			<d2l-select-outcomes-hierarchical
 				class="select-outcomes-hierarchical"
 				rel= "[[_getOutcomeRel(_isFlagOn, isHolistic)]]"


### PR DESCRIPTION
The dialog width was not being set correctly. This resulted in a thinner dialog then desired and the background rubric behind the dialog getting shifted every time the dialog was shown.

**Before**
![before](https://user-images.githubusercontent.com/9043211/110168098-b04f9680-7dc4-11eb-9c4c-475a0bd261b1.PNG)

**After**
![after](https://user-images.githubusercontent.com/9043211/110168108-b47bb400-7dc4-11eb-9257-b004758859c2.PNG)
