### PR TITLE
US114403 - Pass down activity alignment list type name and title

### DIFF
--- a/build/lang/ar.js
+++ b/build/lang/ar.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.Ar = {
 	'criteriaHeading': 'المعايير',
 	'criterion': 'المعيار',
 	'criterionAdded': 'تمت إضافة معيار جديد',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': 'المعيار {index, number} من أصل {count, number}',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': 'تم حذف المعيار {name}',

--- a/build/lang/cy.js
+++ b/build/lang/cy.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.Cy = {
 	'criteriaHeading': 'Meini Prawf',
 	'criterion': 'Maen prawf',
 	'criterionAdded': 'Mae maen prawf newydd wedi cael ei ychwanegu',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': 'Maen prawf {index, number} o {count, number}',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': 'Mae maen prawf {name} wedi cael ei ddileu',

--- a/build/lang/da.js
+++ b/build/lang/da.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.Da = {
 	'criteriaHeading': 'Kriterier',
 	'criterion': 'Kriterium',
 	'criterionAdded': 'Et nyt kriterium blev tilføjet',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': 'Kriterium {index, number} af {count, number}',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': '{name} kriterium slettet',

--- a/build/lang/de.js
+++ b/build/lang/de.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.De = {
 	'criteriaHeading': 'Kriterien',
 	'criterion': 'Kriterium',
 	'criterionAdded': 'Ein neues Kriterium wurde hinzugefügt',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': 'Kriterium {index, number} von {count, number}',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': 'Kriterium {name} gelöscht',

--- a/build/lang/en.js
+++ b/build/lang/en.js
@@ -53,6 +53,7 @@ window.D2L.Rubric.Language.En = {
 	'criterionFeedbackWithCopy': 'will be included in the overall feedback and visible to students',
 	'criterionMoved': '{name} moved to position {positionNumber}.',
 	'criterionNameAriaLabel': 'Name of the criterion in position {positionNumber}.',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionOutOf': 'Criterion {name} is out of {value} points',
 	'criterionPlaceholder': 'Click to edit criterion',
 	'criterionScore': 'Criterion Score',

--- a/build/lang/es-es.js
+++ b/build/lang/es-es.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.EsEs = {
 	'criteriaHeading': 'Criterios',
 	'criterion': 'Criterio',
 	'criterionAdded': 'Se ha agregado un nuevo criterio',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': 'Criterio {index, number} de {count, number}',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': 'Criterio {name} eliminado',

--- a/build/lang/es.js
+++ b/build/lang/es.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.Es = {
 	'criteriaHeading': 'Criterios',
 	'criterion': 'Criterio',
 	'criterionAdded': 'Se agregó un nuevo criterio',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': 'Criterio {index, number} de {count, number}',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': 'Criterio {name} eliminado',

--- a/build/lang/fr-fr.js
+++ b/build/lang/fr-fr.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.FrFr = {
 	'criteriaHeading': 'Critère',
 	'criterion': 'Critère',
 	'criterionAdded': 'Un nouveau critère a été ajouté',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': 'Critère {index, number} sur {count, number}',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': 'Critère {name} supprimé',

--- a/build/lang/fr.js
+++ b/build/lang/fr.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.Fr = {
 	'criteriaHeading': 'Critère',
 	'criterion': 'Critère',
 	'criterionAdded': 'Un nouveau critère a été ajouté',
+	'criterionAlignmentListTitle': '{standardsName} pour le critère {criterionName}',
 	'criterionAriaLabel': 'Critère {index, number} de {count, number}',
 	'criterionCopied': 'Le critère a été copié',
 	'criterionDeleted': 'Critère {name} supprimé',

--- a/build/lang/ja.js
+++ b/build/lang/ja.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.Ja = {
 	'criteriaHeading': '条件',
 	'criterion': '条件',
 	'criterionAdded': '新規条件が追加されました',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': '条件 {index, number}、{count, number} 個',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': '{name} 条件が削除されました',

--- a/build/lang/ko.js
+++ b/build/lang/ko.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.Ko = {
 	'criteriaHeading': '기준',
 	'criterion': '기준',
 	'criterionAdded': '새 기준이 추가되었습니다.',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': '기준 {index, number}/{count, number}개',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': '{name} 기준 삭제됨',

--- a/build/lang/nl.js
+++ b/build/lang/nl.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.Nl = {
 	'criteriaHeading': 'Criteria',
 	'criterion': 'Criterium',
 	'criterionAdded': 'Er is een nieuw criterium toegevoegd',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': 'Criterium {index, number} van {count, number}',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': 'Criterium {name} is verwijderd',

--- a/build/lang/pt.js
+++ b/build/lang/pt.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.Pt = {
 	'criteriaHeading': 'Critérios',
 	'criterion': 'Critério',
 	'criterionAdded': 'Um novo critério foi adicionado',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': 'Critério {index, number} de {count, number}',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': 'Critério {name} excluído',

--- a/build/lang/sv.js
+++ b/build/lang/sv.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.Sv = {
 	'criteriaHeading': 'Kriterier',
 	'criterion': 'Kriterium',
 	'criterionAdded': 'Ett nytt kriterium har lagts till',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': 'Kriterium {index, number} av {count, number}',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': 'Kriteriet {name} borttaget',

--- a/build/lang/tr.js
+++ b/build/lang/tr.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.Tr = {
 	'criteriaHeading': 'Kriterler',
 	'criterion': 'Ölçüt',
 	'criterionAdded': 'Yeni bir kriter eklendi',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': 'Kriter {index, number} / {count, number}',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': '{name} kriteri silindi',

--- a/build/lang/zh-tw.js
+++ b/build/lang/zh-tw.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.ZhTw = {
 	'criteriaHeading': '標準',
 	'criterion': '標準',
 	'criterionAdded': '已新增標準',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': '標準 {index, number}/{count, number}',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': '標準 {name} 已刪除',

--- a/build/lang/zh.js
+++ b/build/lang/zh.js
@@ -44,6 +44,7 @@ window.D2L.Rubric.Language.Zh = {
 	'criteriaHeading': '标准',
 	'criterion': '标准',
 	'criterionAdded': '已添加新标准',
+	'criterionAlignmentListTitle': '{standardsName} for Criterion {criterionName}',
 	'criterionAriaLabel': '标准 {index, number}/{count, number}',
 	'criterionCopied': 'The criterion has been copied',
 	'criterionDeleted': '{name} 标准已删除',

--- a/editor/d2l-rubric-criterion-editor.js
+++ b/editor/d2l-rubric-criterion-editor.js
@@ -57,6 +57,9 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 					transition-property: none;
 					background-color: transparent;
 				};
+
+				--d2l-rubric-editor-browse-outcomes-button-margin: 5px;
+				--d2l-rubric-editor-outcomes-list-label-margin: calc(0.6rem + var(--d2l-rubric-editor-browse-outcomes-button-margin))
 			}
 
 			:host(.show) {
@@ -118,10 +121,15 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 				margin-bottom: 6px;
 			}
 
-			#outcomeText{
-				margin-left: 16px;
-				margin-top: 13px;
-				margin-bottom: 3px;
+			.outcome-text{
+				margin-left: var(--d2l-rubric-editor-outcomes-list-label-margin);
+				@apply --d2l-label-text;
+			}
+
+			.outcomes-wrapper {
+				display:flex;
+				justify-content: center;
+				align-items: center;
 			}
 
 			.feedback-arrow {
@@ -232,15 +240,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 			}
 
 			#browseOutcomesButton{
-				margin-bottom: 5px;
-				margin-left: 5px;
-			}
-
-			#closeButton{
-				right: 0;
-				margin-top: -60px;
-				position: absolute;
-				margin-right: 5px;
+				margin-bottom: var(--d2l-rubric-editor-browse-outcomes-button-margin);
+				margin-left: var(--d2l-rubric-editor-browse-outcomes-button-margin);
 			}
 
 			[hidden] {
@@ -361,9 +362,21 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-editor">
 				<div class="feedback-arrow" data-mobile$="[[!_largeScreen]]" hidden$="[[_hideOutcomes]]">
 					<div class="feedback-arrow-inner" hidden$="[[_hideOutcomes]]"></div>
 				</div>
-				<h5 id="outcomeText" hidden$="[[_hideOutcomes]]">[[outcomesTitle]]</h4>
-				<d2l-activity-alignment-tags  hidden$="[[_hideOutcomes]]" empty="{{_isAlignmentTagListEmpty}}" id="tag" href="[[_getOutcomeHref(entity, _isFlagOn, isHolistic)]]" token="[[token]]" browse-outcomes-text="[[browseOutcomesText]]">
-				</d2l-activity-alignment-tags>
+				<div class="outcomes-wrapper">
+					<div class="outcome-text" hidden$="[[_hideOutcomes]]">
+						[[outcomesTitle]]
+					</div>
+					<d2l-activity-alignment-tags
+						id="tag"
+						hidden$="[[_hideOutcomes]]"
+						empty="{{_isAlignmentTagListEmpty}}"
+						href="[[_getOutcomeHref(entity, _isFlagOn, isHolistic)]]"
+						token="[[token]]"
+						title="[[_getTagsTitle(outcomesTitle, _criterionName)]]"
+						type-name="[[outcomesTitle]]"
+						browse-outcomes-text="[[browseOutcomesText]]">
+					</d2l-activity-alignment-tags>
+				</div>
 			</div>
 		</div>
 	</template>
@@ -994,5 +1007,13 @@ Polymer({
 	},
 	_hideActionMenu: function(actionMenuFlag, canCopy, canDelete) {
 		return !actionMenuFlag || (!canCopy && !canDelete);
+	},
+
+	_getTagsTitle: function(outcomesTitle, criterionName) {
+		if (!outcomesTitle) {
+			return criterionName;
+		}
+
+		return this.localize('criterionAlignmentListTitle', 'standardsName', outcomesTitle, 'criterionName', criterionName);
 	}
 });

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "المعايير",
     "criterion": "المعيار",
     "criterionAdded": "تمت إضافة معيار جديد",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "المعيار {index, number} من أصل {count, number}",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "تم حذف المعيار {name}",

--- a/lang/cy.json
+++ b/lang/cy.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "Meini Prawf",
     "criterion": "Maen prawf",
     "criterionAdded": "Mae maen prawf newydd wedi cael ei ychwanegu",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "Maen prawf {index, number} o {count, number}",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "Mae maen prawf {name} wedi cael ei ddileu",

--- a/lang/da.json
+++ b/lang/da.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "Kriterier",
     "criterion": "Kriterium",
     "criterionAdded": "Et nyt kriterium blev tilføjet",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "Kriterium {index, number} af {count, number}",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "{name} kriterium slettet",

--- a/lang/de.json
+++ b/lang/de.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "Kriterien",
     "criterion": "Kriterium",
     "criterionAdded": "Ein neues Kriterium wurde hinzugefügt",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "Kriterium {index, number} von {count, number}",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "Kriterium {name} gelöscht",

--- a/lang/en.json
+++ b/lang/en.json
@@ -46,6 +46,7 @@
     "criterionFeedbackWithCopy": "will be included in the overall feedback and visible to students",
     "criterionMoved": "{name} moved to position {positionNumber}.",
     "criterionNameAriaLabel": "Name of the criterion in position {positionNumber}.",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionOutOf": "Criterion {name} is out of {value} points",
     "criterionPlaceholder": "Click to edit criterion",
     "criterionScore": "Criterion Score",

--- a/lang/es-es.json
+++ b/lang/es-es.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "Criterios",
     "criterion": "Criterio",
     "criterionAdded": "Se ha agregado un nuevo criterio",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "Criterio {index, number} de {count, number}",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "Criterio {name} eliminado",

--- a/lang/es.json
+++ b/lang/es.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "Criterios",
     "criterion": "Criterio",
     "criterionAdded": "Se agregó un nuevo criterio",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "Criterio {index, number} de {count, number}",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "Criterio {name} eliminado",

--- a/lang/fr-fr.json
+++ b/lang/fr-fr.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "Critère",
     "criterion": "Critère",
     "criterionAdded": "Un nouveau critère a été ajouté",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "Critère {index, number} sur {count, number}",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "Critère {name} supprimé",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "Critère",
     "criterion": "Critère",
     "criterionAdded": "Un nouveau critère a été ajouté",
+    "criterionAlignmentListTitle": "{standardsName} pour le critère {criterionName}",
     "criterionAriaLabel": "Critère {index, number} de {count, number}",
     "criterionCopied": "Le critère a été copié",
     "criterionDeleted": "Critère {name} supprimé",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "条件",
     "criterion": "条件",
     "criterionAdded": "新規条件が追加されました",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "条件 {index, number}、{count, number} 個",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "{name} 条件が削除されました",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "기준",
     "criterion": "기준",
     "criterionAdded": "새 기준이 추가되었습니다.",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "기준 {index, number}/{count, number}개",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "{name} 기준 삭제됨",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "Criteria",
     "criterion": "Criterium",
     "criterionAdded": "Er is een nieuw criterium toegevoegd",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "Criterium {index, number} van {count, number}",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "Criterium {name} is verwijderd",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "Critérios",
     "criterion": "Critério",
     "criterionAdded": "Um novo critério foi adicionado",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "Critério {index, number} de {count, number}",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "Critério {name} excluído",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "Kriterier",
     "criterion": "Kriterium",
     "criterionAdded": "Ett nytt kriterium har lagts till",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "Kriterium {index, number} av {count, number}",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "Kriteriet {name} borttaget",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "Kriterler",
     "criterion": "Ölçüt",
     "criterionAdded": "Yeni bir kriter eklendi",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "Kriter {index, number} / {count, number}",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "{name} kriteri silindi",

--- a/lang/zh-tw.json
+++ b/lang/zh-tw.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "標準",
     "criterion": "標準",
     "criterionAdded": "已新增標準",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "標準 {index, number}/{count, number}",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "標準 {name} 已刪除",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -37,6 +37,7 @@
     "criteriaHeading": "标准",
     "criterion": "标准",
     "criterionAdded": "已添加新标准",
+    "criterionAlignmentListTitle": "{standardsName} for Criterion {criterionName}",
     "criterionAriaLabel": "标准 {index, number}/{count, number}",
     "criterionCopied": "The criterion has been copied",
     "criterionDeleted": "{name} 标准已删除",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-rubric",
-  "version": "3.7.57",
+  "version": "3.7.58",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1053,7 +1053,7 @@
       }
     },
     "@brightspace-ui-labs/multi-select": {
-      "version": "github:BrightspaceUILabs/multi-select#9dc5bc0fb1027ff962ef095ad0e07e307e91e334",
+      "version": "github:BrightspaceUILabs/multi-select#181bf747b7afc23268305e619db061d6f8ac1217",
       "from": "github:BrightspaceUILabs/multi-select#semver:^4",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -2899,7 +2899,7 @@
       "dev": true
     },
     "d2l-activity-alignments": {
-      "version": "github:Brightspace/d2l-activity-alignments#6583162b4909a12a15668fb2a8ebabacfcf4a811",
+      "version": "github:Brightspace/d2l-activity-alignments#76baad105384c76a02aacf860640e5396012b5a8",
       "from": "github:Brightspace/d2l-activity-alignments#semver:^2",
       "requires": {
         "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "lint": "npm run lint:eslint && npm run lint:polymer",
     "lint:eslint": "eslint . --ext .js,.html",
     "lint:polymer": "polymer lint",
+    "format": "npm run format:eslint",
+    "format:eslint": "npm run lint:eslint -- --fix",
     "test": "npm run lint && npm run test:local",
     "test:local": "polymer test --skip-plugin sauce",
     "start": "es-dev-server --app-index demo/index.html --node-resolve --dedupe --watch --open --preserve-symlinks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-rubric",
-  "version": "3.7.57",
+  "version": "3.7.58",
   "description": "Polymer-based web components for D2L Rubrics",
   "main": "d2l-rubric.js",
   "keywords": [


### PR DESCRIPTION
Recommend viewing with [white-space diff off](https://github.com/Brightspace/d2l-rubric/pull/750/files?w=1).

This passes down needed information to the `d2l-activity-alignment-tags` so it can construct helper text for screen reader users.

**Part 1**: https://github.com/Brightspace/d2l-activity-alignments/pull/155.

Tested on **Chrome**, **Firefox** and **Edge** which **NVDA**.

**Note:** This will require updating of the upstream dependencies once **Part 1** merges.