### PR TITLE
removing Polymer style mixins

### DIFF
--- a/d2l-rubric-overall-score.js
+++ b/d2l-rubric-overall-score.js
@@ -123,20 +123,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-overall-score">
 			}
 
 			d2l-scroll-wrapper {
-
-				--d2l-scroll-wrapper-h-scroll: {
-					border-left: 1px dashed var(--d2l-color-mica);
-					border-right: 1px dashed var(--d2l-color-mica);
-				};
-
-				--d2l-scroll-wrapper-left: {
-					border-left: none;
-				};
-
-				--d2l-scroll-wrapper-right: {
-					border-right: none;
-				};
-
 				--d2l-scroll-wrapper-border-color: var(--d2l-color-mica);
 				--d2l-scroll-wrapper-background-color: var(--d2l-color-regolith);
 			}

--- a/editor/d2l-rubric-editor-cell-styles.js
+++ b/editor/d2l-rubric-editor-cell-styles.js
@@ -13,32 +13,17 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-editor-cell-
 		#scroll-wrapper {
 			--d2l-scroll-wrapper-background-color: var(--d2l-table-header-background-color);
 			--d2l-scroll-wrapper-border-color: var(--d2l-color-galena);
-
-			--d2l-scroll-wrapper-h-scroll: {
-				overflow-y: hidden;
-				border-left: 1px dashed var(--d2l-color-galena);
-				border-right: 1px dashed var(--d2l-color-galena);
-				margin-left: var(--d2l-rubric-editor-start-gutter-width);
-				margin-right: var(--d2l-rubric-editor-end-gutter-width);
-			};
-
-			--d2l-scroll-wrapper-sticky: {
-				margin-left: var(--d2l-rubric-editor-start-gutter-width);
-				margin-right: var(--d2l-rubric-editor-end-gutter-width);
-			};
-
-			--d2l-scroll-wrapper-left: {
-				overflow-y: hidden;
-				border-left: none;
-				margin-left: unset;
-			};
-
-			--d2l-scroll-wrapper-right: {
-				overflow-y: hidden;
-				border-right: none;
-				margin-right: unset;
-			};
-
+			--d2l-scroll-wrapper-overflow-border-color: var(--d2l-color-galena);
+		}
+		#scroll-wrapper[h-scrollbar] {
+			padding-left: var(--d2l-rubric-editor-start-gutter-width);
+			padding-right: var(--d2l-rubric-editor-end-gutter-width);
+		}
+		#scroll-wrapper[scrollbar-left] {
+			padding-left: unset;
+		}
+		#scroll-wrapper[scrollbar-right] {
+			padding-right: unset;
 		}
 
 		.cell {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-rubric",
-  "version": "3.7.60",
+  "version": "3.7.61",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-rubric",
-  "version": "3.7.60",
+  "version": "3.7.61",
   "description": "Polymer-based web components for D2L Rubrics",
   "main": "d2l-rubric.js",
   "keywords": [


### PR DESCRIPTION
Before we can migrate `d2l-table` from Polymer to Lit, we need to remove usages to its Polymer style mixins -- which aren't supported in Lit.