### PR TITLE
removing redundant attributes

### DIFF
--- a/editor/d2l-rubric-criteria-group-editor.js
+++ b/editor/d2l-rubric-criteria-group-editor.js
@@ -103,7 +103,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criteria-group-edito
 			</div>
 		</template>
 
-		<d2l-scroll-wrapper id="scroll-wrapper" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right" show-actions="" check-scroll-delta-value="1">
+		<d2l-scroll-wrapper id="scroll-wrapper" show-actions check-scroll-delta-value="1">
 			<h2 class="screen-reader">[[_getGroupHeadingText(_groupName, showGroupName)]]</h2>
 			<d2l-offscreen>[[_getRubricStructureLabel(_levelCount, _criterionCount)]]</d2l-offscreen>
 			<div class="criteria-group">

--- a/editor/d2l-rubric-overall-levels-editor.js
+++ b/editor/d2l-rubric-overall-levels-editor.js
@@ -165,7 +165,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-overall-leve
 			<div class="sub-title">[[localize('overallScoreDescription')]]</div>
 		</div>
 
-		<d2l-scroll-wrapper id="scroll-wrapper" start-icon="d2l-tier1:chevron-left" end-icon="d2l-tier1:chevron-right" show-actions="" check-scroll-delta-value="1">
+		<d2l-scroll-wrapper id="scroll-wrapper" show-actions check-scroll-delta-value="1">
 			<div id="level-header" class="editor-section">
 				<div class="gutter-left">
 					<d2l-button-icon on-click="_handlePrependOverallLevel" on-focus="_onPrependFocus" icon="d2l-tier2:add" text="[[localize('addOverallLevelPrepend', 'name', '')]]" disabled="[[!_canPrepend]]" type="button">


### PR DESCRIPTION
This is just setting these to the default values. These attributes weren't ever used, so the plan is to remove them in a future change to `d2l-table` prior to the Lit migration.