### PR TITLE
removing unnecessary overrides

### DIFF
--- a/d2l-rubric-overall-score.js
+++ b/d2l-rubric-overall-score.js
@@ -122,11 +122,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-overall-score">
 				flex-direction: row;
 			}
 
-			d2l-scroll-wrapper {
-				--d2l-scroll-wrapper-border-color: var(--d2l-color-mica);
-				--d2l-scroll-wrapper-background-color: var(--d2l-color-regolith);
-			}
-
 			d2l-rubric-competencies-icon {
 				margin-top: 1px;
 				margin-left: 10px;

--- a/editor/d2l-rubric-editor-cell-styles.js
+++ b/editor/d2l-rubric-editor-cell-styles.js
@@ -10,11 +10,6 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-rubric-editor-cell-
 			--d2l-rubric-editor-end-gutter-width: 2.5rem; /* trash can width = 50px including halo */
 		}
 
-		#scroll-wrapper {
-			--d2l-scroll-wrapper-background-color: var(--d2l-table-header-background-color);
-			--d2l-scroll-wrapper-border-color: var(--d2l-color-galena);
-			--d2l-scroll-wrapper-overflow-border-color: var(--d2l-color-galena);
-		}
 		#scroll-wrapper[h-scrollbar] {
 			padding-left: var(--d2l-rubric-editor-start-gutter-width);
 			padding-right: var(--d2l-rubric-editor-end-gutter-width);


### PR DESCRIPTION
We're [changing scroll-wrapper](https://github.com/BrightspaceUI/table/pull/234/files) so that the action button colours are no longer configurable -- they just use nice defaults that should work for everyone.

So setting these variables is no longer necessary.