### PR TITLE
Remove pre-criteria group page break when printing

### DIFF
--- a/d2l-rubric-criteria-group.js
+++ b/d2l-rubric-criteria-group.js
@@ -222,8 +222,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criteria-group">
 			@media print {
 
 				:host {
-					page-break-before: auto;
-					page-break-inside: avoid;
+					page-break-before: avoid;
 					page-break-after: auto;
 				}
 				d2l-table { 

--- a/d2l-rubric-criterion-cell.js
+++ b/d2l-rubric-criterion-cell.js
@@ -70,7 +70,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-cell">
 
 				/* Adjust checkmark to handle no minimum column width when printing */
 				.check-icon.center {
-					width: 75%
+					width: 90%; /* Table cells have ~5% padding */
 				}
 				.check-icon.corner {
 					position: absolute;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-rubric",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-rubric",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Polymer-based web components for D2L Rubrics",
   "main": "d2l-rubric.js",
   "keywords": [


### PR DESCRIPTION
Issue found during testing. Was causing criteria groups to skip to the next printed page if they couldn't fully fit on the first. When combined with the truncation issue, this was causing large rubrics to not appear at all when printed from the preview view.

Additional improvement: checkboxes in empty graded cells now appear more centered when printed.