### PR TITLE
Fix accordion querySelector

### DIFF
--- a/d2l-rubric-adapter.js
+++ b/d2l-rubric-adapter.js
@@ -78,54 +78,48 @@ window.customElements.define('d2l-rubric-adapter', class RubricAdapter extends m
 				<template
 					is="dom-if"
 					id="compact-view-template"
-					if="[[compact]]"
+					if="[[_showAttachedCompactView(compact, detachedView)]]"
 					restamp
 				>
-					<template
-						is="dom-if"
-						id="attached-view-template"
-						if="[[!detachedView]]"
-						restamp
-					>
-						<d2l-labs-accordion flex>
-							<d2l-labs-accordion-collapse flex>
-								<div slot="header">
+					<d2l-labs-accordion flex>
+						<d2l-labs-accordion-collapse flex>
+							<div slot="header">
 								<d2l-icon
-										class="rubric-header-icon"
-										icon="[[_getRubricIcon(assessmentEntity, detachedView)]]">
-									</d2l-icon>
-									<span class="rubric-header-title-container">
-										<div class="rubric-header-title">[[rubricName]]</div>
-										<div class="rubric-header-out-of-container">
-											<span class="rubric-header-out-of-text">
-												[[scoreText]]
-											</span>
-										</div>
-									</span>
-								</div>
-								<slot></slot>
-							</d2l-labs-accordion-collapse>
-						</d2l-labs-accordion>
-					</template>
-					<template
-						is="dom-if"
-						id="detached-view-template"
-						if="[[detachedView]]"
-					>
-						<div slot="header">
-							<d2l-icon
-								class="rubric-header-icon-detached"
-								icon="[[_getRubricIcon(assessmentEntity, detachedView)]]">
-							</d2l-icon>
-							<span class="rubric-header-title-container">
-								<div class="rubric-header-title-detached">[[rubricName]]</div>
-							</span>
-							<span class="rubric-label-detached-container">
-								<div class="rubric-label-detached">[[localize('detached')]]</div>
-								<div style="clear: both;" />
-							</span>
-						</div>
-					</template>
+									class="rubric-header-icon"
+									icon="[[_getRubricIcon(assessmentEntity, detachedView)]]">
+								</d2l-icon>
+								<span class="rubric-header-title-container">
+									<div class="rubric-header-title">[[rubricName]]</div>
+									<div class="rubric-header-out-of-container">
+										<span class="rubric-header-out-of-text">
+											[[scoreText]]
+										</span>
+									</div>
+								</span>
+							</div>
+							<slot></slot>
+						</d2l-labs-accordion-collapse>
+					</d2l-labs-accordion>
+				</template>
+				<template
+					is="dom-if"
+					id="detached-compact-view-template"
+					if="[[_showDetachedCompactView(compact, detachedView)]]"
+					restamp
+				>
+					<div slot="header">
+						<d2l-icon
+							class="rubric-header-icon-detached"
+							icon="[[_getRubricIcon(assessmentEntity, detachedView)]]">
+						</d2l-icon>
+						<span class="rubric-header-title-container">
+							<div class="rubric-header-title-detached">[[rubricName]]</div>
+						</span>
+						<span class="rubric-label-detached-container">
+							<div class="rubric-label-detached">[[localize('detached')]]</div>
+							<div style="clear: both;" />
+						</span>
+					</div>
 				</template>
 				<template is="dom-if" if="[[!compact]]" restamp>
 					<slot></slot>
@@ -152,6 +146,14 @@ window.customElements.define('d2l-rubric-adapter', class RubricAdapter extends m
 			: 'rubric';
 
 		return tierName + ':' + iconName;
+	}
+
+	_showAttachedCompactView(compact, detachedView) {
+		return compact && !detachedView;
+	}
+
+	_showDetachedCompactView(compact, detachedView) {
+		return compact && detachedView;
 	}
 
 	_onConnected() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-rubric",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-rubric",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "description": "Polymer-based web components for D2L Rubrics",
   "main": "d2l-rubric.js",
   "keywords": [


### PR DESCRIPTION
@JamieTran traced an event detection issue in consistent-evaluation back to a failing querySelector in d2l-rubric-adapter. This is due to recent changes in the rendered content to facilitate the detached compact view.

This PR adjusts the content again to ensure the DOM query can find the expandable accordion, if present. 