### PR TITLE
syncing middle section when entities change

### DIFF
--- a/editor/d2l-rubric-overall-levels-editor.js
+++ b/editor/d2l-rubric-overall-levels-editor.js
@@ -331,6 +331,7 @@ Polymer({
 	_notifyResize: function() {
 		afterNextRender(this, function() {
 			this.$$('d2l-scroll-wrapper').notifyResize();
+			this.syncMiddleSectionSize();
 		}.bind(this));
 	},
 	// eslint-disable-next-line no-unused-vars

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-rubric",
-  "version": "3.8.7",
+  "version": "3.8.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-rubric",
-  "version": "3.8.7",
+  "version": "3.8.8",
   "description": "Polymer-based web components for D2L Rubrics",
   "main": "d2l-rubric.js",
   "keywords": [


### PR DESCRIPTION
This `syncMiddleSectionSize()` method is called to keep the bottom and top row (which is wrapped in a scroll wrapper) in sync:
![Screen Shot 2021-05-13 at 4 15 31 PM](https://user-images.githubusercontent.com/5491151/118182038-850da700-b406-11eb-9c4d-f09015e9931b.png)

After converting scroll wrapper to Lit, the timing isn't quite the same as it was before... I think things are loading quicker such that all the calculations are happening before any of the hypermedia entities are loaded. So this change just forces a recalculation when the entities change.