### PR TITLE
checking size when entity changes

### DIFF
--- a/editor/d2l-rubric-levels-editor.js
+++ b/editor/d2l-rubric-levels-editor.js
@@ -210,6 +210,7 @@ Polymer({
 			return;
 		}
 		this._levels = entity.getSubEntitiesByClass(this.HypermediaClasses.rubrics.level);
+		this.checkSize();
 	},
 	_canPrependLevel: function(entity) {
 		return entity && entity.hasActionByName('prepend');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-rubric",
-  "version": "3.8.8",
+  "version": "3.8.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-rubric",
-  "version": "3.8.8",
+  "version": "3.8.9",
   "description": "Polymer-based web components for D2L Rubrics",
   "main": "d2l-rubric.js",
   "keywords": [


### PR DESCRIPTION
Almost identical to #776, another timing issue with the new scroll wrapper. The size of the "initial feedback" row ends up being off the first time it renders:

![Screen Shot 2021-05-17 at 6 40 36 PM](https://user-images.githubusercontent.com/5491151/118565090-8f4ddf00-b73f-11eb-9345-221f02681390.png)

This change causes a size calculation check when the underlying entity changes.