### PR TITLE
mobile rubric style updates

### DIFF
--- a/d2l-rubric-criterion-mobile.js
+++ b/d2l-rubric-criterion-mobile.js
@@ -28,9 +28,9 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-mobile">
 			.criterion-description-container {
 				@apply --d2l-body-small-text;
 				display: inline-flex;
-				width:100%;
-				margin-top: 24px;
-				margin-bottom: 0.33rem;
+				width: 100%;
+				margin-top: 4px;
+				margin-bottom: 0.5rem;
 			}
 			.criterion-description {
 				padding-top: 6px;
@@ -83,14 +83,16 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-criterion-mobile">
 
 			.level-name {
 				display: flex;
-			}
-			:host([compact]) .level-name {
-				justify-content: space-between;
-				align-items: center;
+				color: var(--d2l-color-celestine);
 			}
 
 			.level-text {
-				font-weight: bold;
+				padding: calc(0.5rem + 3px) 0;
+			}
+
+			:host([compact]) .level-name {
+				justify-content: space-between;
+				align-items: center;
 			}
 
 			.level-bullet.assessed,

--- a/d2l-rubric-editable-score.js
+++ b/d2l-rubric-editable-score.js
@@ -26,30 +26,22 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-editable-score">
 			#editable-container {
 				display: block;
 				outline: none;
+				border: thin solid transparent;
+				padding: 0.5rem;
+				padding-left: 0.6rem;
 			}
 			:host([overridden-styling]) #editable-container {
 				border-radius: 0.3rem;
 				background-color: var(--d2l-color-celestine-plus-2);
 			}
-			:host([compact]:not([editor-styling])) #editable-container {
-				padding: 0.25rem;
-				margin: -0.25rem;
-			}
-			:host(:not([compact]):not([editor-styling])) #editable-container {
-				padding: 0.5rem 0.5rem 0.5rem 0.6rem;
-			}
-			:host(:not([compact]):not([editor-styling])) #editable-container:focus,
-			:host(:not([compact]):not([editor-styling])) #editable-container:hover {
-				padding: calc(0.5rem - 1px) calc(0.5rem - 1px) calc(0.5rem - 1px) calc(0.6rem - 1px);
-			}
-			:host(.assessable[compact]:not([editor-styling])) #editable-container:focus,
-			:host(.assessable[compact]:not([editor-styling])) #editable-container:hover {
-				padding: calc(0.25rem - 1px);
-			}
 			:host(.assessable:not([editor-styling])) #editable-container:focus,
 			:host(.assessable:not([editor-styling])) #editable-container:hover {
 				border-radius: 0.3rem;
-				border: 1px solid var(--d2l-color-celestine);
+				border-color: var(--d2l-color-celestine);
+			}
+			:host([editor-styling]) #editable-container {
+				padding-top: 0;
+				padding-bottom: 0;
 			}
 			.total-score-container {
 				display: flex;
@@ -77,7 +69,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-editable-score">
 			}
 
 			#out-of {
-				@apply --d2l-body-compact-text;
 				margin-left: 3px;
 				display: inline;
 				line-height: 2.2rem;
@@ -89,9 +80,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-editable-score">
 
 			.editing-component {
 				margin-right: 0;
-				display: inline-flex;
-				padding: 6px 12px 6px 0;
-				align-items : center;
 			}
 
 			#clear-button {

--- a/d2l-rubric-levels-mobile.js
+++ b/d2l-rubric-levels-mobile.js
@@ -38,7 +38,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-levels-mobile">
 				color: var(--d2l-color-galena);
 				outline: none;
 				flex: 1;
-				height: 18px;
+				height: 24px;
 				align-self: center;
 			}
 			.level:not(.selected):not(:last-of-type),
@@ -73,10 +73,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-levels-mobile">
 			}
 
 			.level.selected {
-				background-color: var(--d2l-color-gypsum);
-				border: 1px solid var(--d2l-color-galena);
-				border-radius: 6px !important;
-				height: 30px;
+				border-radius: 6px;
+				height: 36px;
 			}
 			.level:hover {
 				cursor: pointer;
@@ -109,11 +107,11 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-levels-mobile">
 			.level:focus .level-tab-focus {
 				border: 1px solid var(--d2l-color-celestine-minus-1);
 				margin: 2px;
-				height: 12px;
+				height: 18px;
 			}
 			.level.selected:focus .level-tab-focus {
-				border-radius: 6px;
-				height: 24px;
+				border-radius: 4px;
+				height: 30px;
 			}
 			.level:not(.selected):focus:last-of-type .level-tab-focus,
 			:dir(rtl) .level:not(.selected):focus:first-of-type .level-tab-focus {
@@ -329,9 +327,7 @@ Polymer({
 	},
 
 	_isSelected: function(index, selected) {
-		return selected >= 0
-			? index === selected
-			: index === 0;
+		return selected >= 0 && index === selected;
 	},
 
 	_isHovered: function(index, hovered) {
@@ -356,7 +352,6 @@ Polymer({
 		if (criterionCells && this._isAssessedLevel(index, criterionCells[index], cellAssessmentMap)) {
 			className += ' assessed';
 		}
-
 		return className;
 	},
 


### PR DESCRIPTION
Rally: [US126933](https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fuserstory%2F521003693996)

Follow-up from #779 

Part of the inline grading rubric revamp - removes default selection tile, improving clarity with regards to which level is selected