### PR TITLE
mobile rubric assessment saving

### DIFF
--- a/d2l-rubric-criterion-mobile.js
+++ b/d2l-rubric-criterion-mobile.js
@@ -358,18 +358,32 @@ Polymer({
 		}
 	},
 
+	_isCachePrimed: function() {
+		return !!this._levelEntities;
+	},
+
+	_isCachePriming: function(assessmentCriterionEntity) {
+		return !!assessmentCriterionEntity.rel;
+	},
+
+	_isCriterionSaving: function(assessmentCriterionEntity) {
+		return this._save
+			&& this._save.entity
+			&& this._save.entity.getLink().href !== assessmentCriterionEntity.getAction().href;
+	},
+
+	_canUpdateAssessment: function(assessmentCriterionEntity) {
+		return !this._isCachePrimed() ||
+			!this._isCachePriming(assessmentCriterionEntity)
+			&& this._isCriterionSaving(assessmentCriterionEntity)
+			&& !--this._save.ops;
+	},
+
 	_selectAssessedLevel: function(cells, cellAssessmentMap, assessmentCriterionEntity) {
 		if (!cells
-		|| !cellAssessmentMap
-		|| !Object.keys(cellAssessmentMap).length
+		|| !cellAssessmentMap || !Object.keys(cellAssessmentMap).length
 		|| !assessmentCriterionEntity
-		|| this._levelEntities && (
-			assessmentCriterionEntity.rel
-			|| !this._save
-			|| !this._save.entity
-			|| this._save.entity.getLink().href !== assessmentCriterionEntity.getAction().href
-			|| --this._save.ops
-		)) {
+		|| !this._canUpdateAssessment(assessmentCriterionEntity)) {
 			return;
 		}
 		if (this._save && !this._save.ops) {

--- a/d2l-rubric-criterion-mobile.js
+++ b/d2l-rubric-criterion-mobile.js
@@ -331,19 +331,18 @@ Polymer({
 	},
 
 	selectCell: function(entityGetter) {
-		const criterion = this;
 		const helper = this.CriterionCellAssessmentHelper;
-		const entityWrapper = () => {
+		const entityWrapper = (() => {
 			const entity = entityGetter();
-			criterion._save.entity = entity;
+			this._save.entity = entity;
 			return entity;
-		};
+		}).bind(this);
 
 		const DEBOUNCE_DURATION = 1000;
-		const timeout = setTimeout(() => {
+		const timeout = setTimeout((() => {
 			helper.selectAsync(entityWrapper);
-			criterion._save.ops += 1;
-		}, DEBOUNCE_DURATION);
+			this._save.ops += 1;
+		}).bind(this), DEBOUNCE_DURATION);
 
 		if (this._save) {
 			clearTimeout(this._save.timeout);

--- a/d2l-rubric-levels-mobile.js
+++ b/d2l-rubric-levels-mobile.js
@@ -214,7 +214,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-rubric-levels-mobile">
 						on-mousedown="_handleMouseDown"
 						on-mouseover="_handleMouseOver"
 						on-mouseout="_handleMouseOut"
-						on-click="_handleClick"
 						on-track="_handleTrack"
 					>
 						<template is="dom-if" if="[[_isThumbVisible(index, selected)]]">
@@ -386,11 +385,13 @@ Polymer({
 	},
 
 	_selectLevel: function(level) {
+		if (this.focused === level.dataIndex
+		&& this.selected === level.dataIndex) {
+			return;
+		}
 		this._focusLevel(level.dataIndex);
 		if (!this.readOnly) {
-			this.CriterionCellAssessmentHelper.selectAsync(
-				() => this.cellAssessmentMap[level.dataset.cellHref]
-			);
+			this._getCriterion().selectCell(() => this.cellAssessmentMap[level.dataset.cellHref]);
 		}
 	},
 
@@ -510,8 +511,12 @@ Polymer({
 		return this.shadowRoot.querySelector(`#level-tab${index}`);
 	},
 
+	_getCriterion: function() {
+		return this.getRootNode().host;
+	},
+
 	_getCriterionName: function() {
-		return this.getRootNode().host._name;
+		return this._getCriterion()._name;
 	},
 
 	_getCriterionCellHref: function(criterionCells, index) {
@@ -546,14 +551,9 @@ Polymer({
 	},
 
 	_handleMouseDown: function(evt) {
-		this._focusLevel(evt.currentTarget.dataIndex);
-	},
-
-	_handleClick: function(evt) {
 		if (this._preventClick) {
 			return;
 		}
-		this.shadowRoot.querySelector('input.level-slider').value = evt.currentTarget.dataIndex;
 		this.focusSlider(evt);
 		this._selectLevel(evt.currentTarget);
 		evt.preventDefault();


### PR DESCRIPTION
Rally: [DE43477](https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fdefect%2F603621606540)

Implements a 1 second debounce timeout at the criterion level to avoid unnecessary post requests. Also blocks regressive cache priming for save responses from taking effect on the frontend.